### PR TITLE
refactor: audit and harden FrilDay desktop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: 20
+          bun-version: 1.2.2
 
       - name: Install dependencies
-        run: npm install
+        run: bun install --frozen-lockfile
+
+      - name: Test desktop app
+        run: npm run test
 
       - name: Lint desktop app
         run: npm run lint
@@ -45,8 +48,37 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install Tauri Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Check Rust formatting
+        run: |
+          cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml -- --check
+          cargo fmt --manifest-path apps/server/Cargo.toml -- --check
+          cargo fmt --manifest-path crates/frilday-core/Cargo.toml -- --check
+
       - name: Check server crate
         run: cargo check --manifest-path apps/server/Cargo.toml
 
+      - name: Test server crate
+        run: cargo test --manifest-path apps/server/Cargo.toml
+
       - name: Check core crate
         run: cargo check --manifest-path crates/frilday-core/Cargo.toml
+
+      - name: Test core crate
+        run: cargo test --manifest-path crates/frilday-core/Cargo.toml
+
+      - name: Check desktop Tauri crate
+        run: cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -49,4 +49,5 @@ macOS bundle output:
 
 - this app is the active product surface right now
 - the desktop runtime is local-first and does not require a local Axum server
+- server and shared core extraction are planned at the repo level
 - broader direction is documented in [../../docs/ARCHITECTURE.md](../../docs/ARCHITECTURE.md)

--- a/apps/desktop/bun.lock
+++ b/apps/desktop/bun.lock
@@ -6,6 +6,7 @@
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@tailwindcss/vite": "^4.2.1",
+        "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-notification": "^2.3.3",
         "@tauri-apps/plugin-sql": "^2.3.2",
         "@tauri-apps/plugin-store": "^2.4.2",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "bun test",
     "preview": "vite preview",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@tailwindcss/vite": "^4.2.1",
+    "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-sql": "^2.3.2",
     "@tauri-apps/plugin-store": "^2.4.2",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1191,6 +1191,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+ "sqlx",
  "tauri",
  "tauri-build",
  "tauri-plugin-log",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ tauri-build = { version = "2.5.4", features = [] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+sqlx = { version = "0.8", default-features = false, features = ["json", "runtime-tokio", "sqlite"] }
 log = "0.4"
 tauri = { version = "2.10.0", features = [] }
 tauri-plugin-log = "2"

--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-  tauri_build::build()
+    tauri_build::build()
 }

--- a/apps/desktop/src-tauri/src/bootstrap.rs
+++ b/apps/desktop/src-tauri/src/bootstrap.rs
@@ -3,7 +3,7 @@ use tauri::App;
 use crate::{migration::migrate_legacy_app_config_dir, plugins::register_plugins};
 
 pub fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {
-  migrate_legacy_app_config_dir(app.handle())?;
-  register_plugins(app.handle())?;
-  Ok(())
+    migrate_legacy_app_config_dir(app.handle())?;
+    register_plugins(app.handle())?;
+    Ok(())
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4,11 +4,11 @@ mod plugins;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-  tauri::Builder::default()
-    .plugin(tauri_plugin_store::Builder::new().build())
-    .plugin(tauri_plugin_sql::Builder::default().build())
-    .plugin(tauri_plugin_notification::init())
-    .setup(bootstrap::setup)
-    .run(tauri::generate_context!())
-    .expect("error while running tauri application");
+    tauri::Builder::default()
+        .plugin(tauri_plugin_store::Builder::new().build())
+        .plugin(tauri_plugin_sql::Builder::default().build())
+        .plugin(tauri_plugin_notification::init())
+        .setup(bootstrap::setup)
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod bootstrap;
 mod migration;
+mod persistence;
 mod plugins;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -8,6 +9,9 @@ pub fn run() {
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_sql::Builder::default().build())
         .plugin(tauri_plugin_notification::init())
+        .invoke_handler(tauri::generate_handler![
+            persistence::execute_app_transaction
+        ])
         .setup(bootstrap::setup)
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-  frilday_desktop_lib::run();
+    frilday_desktop_lib::run();
 }

--- a/apps/desktop/src-tauri/src/migration.rs
+++ b/apps/desktop/src-tauri/src/migration.rs
@@ -43,7 +43,7 @@ pub fn migrate_legacy_app_config_dir(app: &tauri::AppHandle) -> tauri::Result<()
   fs::create_dir_all(&current_config_dir)?;
   fs::copy(legacy_db_path, current_db_path)?;
 
-  Ok(())
+    Ok(())
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/migration.rs
+++ b/apps/desktop/src-tauri/src/migration.rs
@@ -1,4 +1,7 @@
-use std::{fs, path::{Path, PathBuf}};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use tauri::Manager;
 
@@ -6,70 +9,65 @@ use tauri::Manager;
 const DB_FILE_NAME: &str = "daily_check.db";
 // Keep all prior identifiers so changing the product identifier does not
 // strand an existing local database.
-const LEGACY_IDENTIFIERS: [&str; 3] = [
-  "app.dailycheck",
-  "com.mars112.dailycheck",
-  "dailycheck",
-];
+const LEGACY_IDENTIFIERS: [&str; 3] = ["app.dailycheck", "com.mars112.dailycheck", "dailycheck"];
 
 fn find_legacy_database(config_root: &Path) -> Option<PathBuf> {
-  LEGACY_IDENTIFIERS
-    .iter()
-    .map(|identifier| config_root.join(identifier).join(DB_FILE_NAME))
-    .find(|path| fs::metadata(path).is_ok())
+    LEGACY_IDENTIFIERS
+        .iter()
+        .map(|identifier| config_root.join(identifier).join(DB_FILE_NAME))
+        .find(|path| fs::metadata(path).is_ok())
 }
 
 pub fn migrate_legacy_app_config_dir(app: &tauri::AppHandle) -> tauri::Result<()> {
-  let current_config_dir: PathBuf = match app.path().app_config_dir() {
-    Ok(path) => path,
-    Err(_) => return Ok(()),
-  };
+    let current_config_dir: PathBuf = match app.path().app_config_dir() {
+        Ok(path) => path,
+        Err(_) => return Ok(()),
+    };
 
-  let current_db_path = current_config_dir.join(DB_FILE_NAME);
-  if fs::metadata(&current_db_path).is_ok() {
-    return Ok(());
-  }
+    let current_db_path = current_config_dir.join(DB_FILE_NAME);
+    if fs::metadata(&current_db_path).is_ok() {
+        return Ok(());
+    }
 
-  let config_root = match current_config_dir.parent() {
-    Some(parent) => parent.to_path_buf(),
-    None => return Ok(()),
-  };
+    let config_root = match current_config_dir.parent() {
+        Some(parent) => parent.to_path_buf(),
+        None => return Ok(()),
+    };
 
-  let legacy_db_path = match find_legacy_database(&config_root) {
-    Some(path) => path,
-    None => return Ok(()),
-  };
+    let legacy_db_path = match find_legacy_database(&config_root) {
+        Some(path) => path,
+        None => return Ok(()),
+    };
 
-  fs::create_dir_all(&current_config_dir)?;
-  fs::copy(legacy_db_path, current_db_path)?;
+    fs::create_dir_all(&current_config_dir)?;
+    fs::copy(legacy_db_path, current_db_path)?;
 
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-  use super::*;
-  use std::time::{SystemTime, UNIX_EPOCH};
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
-  #[test]
-  fn finds_legacy_database_in_the_config_root() {
-    let nonce = SystemTime::now()
-      .duration_since(UNIX_EPOCH)
-      .expect("system clock should be after Unix epoch")
-      .as_nanos();
-    let root = std::env::temp_dir().join(format!(
-      "frilday-migration-test-{}-{nonce}",
-      std::process::id()
-    ));
-    let legacy_db_path = root.join("app.dailycheck").join(DB_FILE_NAME);
+    #[test]
+    fn finds_legacy_database_in_the_config_root() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after Unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "frilday-migration-test-{}-{nonce}",
+            std::process::id()
+        ));
+        let legacy_db_path = root.join("app.dailycheck").join(DB_FILE_NAME);
 
-    fs::create_dir_all(legacy_db_path.parent().expect("database has a parent"))
-      .expect("legacy config directory should be created");
-    fs::write(&legacy_db_path, b"legacy database")
-      .expect("legacy database should be created");
+        fs::create_dir_all(legacy_db_path.parent().expect("database has a parent"))
+            .expect("legacy config directory should be created");
+        fs::write(&legacy_db_path, b"legacy database").expect("legacy database should be created");
 
-    assert_eq!(find_legacy_database(&root), Some(legacy_db_path));
+        assert_eq!(find_legacy_database(&root), Some(legacy_db_path));
 
-    fs::remove_dir_all(root).expect("temporary migration directory should be removed");
-  }
+        fs::remove_dir_all(root).expect("temporary migration directory should be removed");
+    }
 }

--- a/apps/desktop/src-tauri/src/persistence.rs
+++ b/apps/desktop/src-tauri/src/persistence.rs
@@ -1,0 +1,143 @@
+use serde::Deserialize;
+use serde_json::Value;
+use tauri::State;
+use tauri_plugin_sql::{DbInstances, DbPool};
+
+const DB_URL: &str = "sqlite:daily_check.db";
+
+#[derive(Debug, Deserialize)]
+pub struct SqlStatement {
+    sql: String,
+    #[serde(default)]
+    bind: Vec<Value>,
+}
+
+#[tauri::command]
+pub async fn execute_app_transaction(
+    db_instances: State<'_, DbInstances>,
+    statements: Vec<SqlStatement>,
+) -> Result<(), String> {
+    let pool = {
+        let instances = db_instances.0.read().await;
+        match instances.get(DB_URL) {
+            Some(DbPool::Sqlite(pool)) => pool.clone(),
+            None => return Err(format!("Database is not loaded: {DB_URL}")),
+        }
+    };
+
+    execute_transaction(&pool, statements).await
+}
+
+async fn execute_transaction(
+    pool: &sqlx::Pool<sqlx::Sqlite>,
+    statements: Vec<SqlStatement>,
+) -> Result<(), String> {
+    let mut transaction = pool
+        .begin()
+        .await
+        .map_err(|error| format!("Failed to begin app data transaction: {error}"))?;
+
+    for (index, statement) in statements.into_iter().enumerate() {
+        let mut query = sqlx::query(&statement.sql);
+        for value in statement.bind {
+            if value.is_null() {
+                query = query.bind(None::<Value>);
+            } else if value.is_string() {
+                query = query.bind(value.as_str().unwrap_or_default().to_owned());
+            } else if let Some(number) = value.as_number() {
+                query = query.bind(number.as_f64().unwrap_or_default());
+            } else {
+                query = query.bind(value);
+            }
+        }
+
+        if let Err(error) = query.execute(&mut *transaction).await {
+            let message = format!("Failed to execute app data statement {index}: {error}");
+            if let Err(rollback_error) = transaction.rollback().await {
+                return Err(format!("{message}; rollback failed: {rollback_error}"));
+            }
+            return Err(message);
+        }
+    }
+
+    transaction
+        .commit()
+        .await
+        .map_err(|error| format!("Failed to commit app data transaction: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    #[test]
+    fn commits_all_statements_as_one_transaction() {
+        tauri::async_runtime::block_on(async {
+            let pool = SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect("sqlite::memory:")
+                .await
+                .unwrap();
+
+            sqlx::query("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+                .execute(&pool)
+                .await
+                .unwrap();
+
+            execute_transaction(
+                &pool,
+                vec![SqlStatement {
+                    sql: "INSERT INTO items (name) VALUES (?)".to_owned(),
+                    bind: vec![Value::String("saved".to_owned())],
+                }],
+            )
+            .await
+            .unwrap();
+
+            let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM items")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+            assert_eq!(count, 1);
+        });
+    }
+
+    #[test]
+    fn rolls_back_all_statements_when_one_fails() {
+        tauri::async_runtime::block_on(async {
+            let pool = SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect("sqlite::memory:")
+                .await
+                .unwrap();
+
+            sqlx::query("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+                .execute(&pool)
+                .await
+                .unwrap();
+
+            let result = execute_transaction(
+                &pool,
+                vec![
+                    SqlStatement {
+                        sql: "INSERT INTO items (name) VALUES (?)".to_owned(),
+                        bind: vec![Value::String("rolled back".to_owned())],
+                    },
+                    SqlStatement {
+                        sql: "INSERT INTO missing (name) VALUES (?)".to_owned(),
+                        bind: vec![Value::String("failure".to_owned())],
+                    },
+                ],
+            )
+            .await;
+
+            assert!(result.is_err());
+            let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM items")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+            assert_eq!(count, 0);
+        });
+    }
+}

--- a/apps/desktop/src-tauri/src/plugins.rs
+++ b/apps/desktop/src-tauri/src/plugins.rs
@@ -1,13 +1,13 @@
 use tauri::{AppHandle, Result};
 
 pub fn register_plugins(app: &AppHandle) -> Result<()> {
-  if cfg!(debug_assertions) {
-    app.plugin(
-      tauri_plugin_log::Builder::default()
-        .level(log::LevelFilter::Info)
-        .build(),
-    )?;
-  }
+    if cfg!(debug_assertions) {
+        app.plugin(
+            tauri_plugin_log::Builder::default()
+                .level(log::LevelFilter::Info)
+                .build(),
+        )?;
+    }
 
-  Ok(())
+    Ok(())
 }

--- a/apps/desktop/src/app/App.tsx
+++ b/apps/desktop/src/app/App.tsx
@@ -89,7 +89,7 @@ export default function App() {
                 completions={m.completions}
                 timeEntries={m.timeEntries}
                 nowIso={m.nowIso}
-                runningTaskIdToday={m.runningTaskIdToday}
+                runningTaskId={m.runningTaskId}
                 getMemoText={m.getMemoText}
                 onSaveMemo={m.handleSaveDailyMemo}
                 onToggleToday={(task: Task) =>
@@ -126,7 +126,7 @@ export default function App() {
                 onError={m.setError}
                 timeEntries={m.timeEntries}
                 nowIso={m.nowIso}
-                runningTaskIdToday={m.runningTaskIdToday}
+                runningTaskId={m.runningTaskId}
                 onStartTimer={m.handleStartTimer}
                 onStopTimer={m.handleStopTimer}
               />

--- a/apps/desktop/src/app/hooks/useAppModel.ts
+++ b/apps/desktop/src/app/hooks/useAppModel.ts
@@ -8,7 +8,7 @@ import type { Tab } from '../layout/HeaderTabs';
 import type { CreateTaskInput } from '../../features/task/components/TaskForm';
 import { getNotifier } from '../di/notifierDI';
 import { getDailyMemoText } from '../../domain/memo';
-import { isVisibleInWeek } from '../../domain/scheduleLimit';
+import { isVisibleInWeek } from '../../domain/schedule/scheduleLimit';
 
 export function useAppModel() {
   const {

--- a/apps/desktop/src/app/hooks/useAppModel.ts
+++ b/apps/desktop/src/app/hooks/useAppModel.ts
@@ -9,6 +9,7 @@ import type { CreateTaskInput } from '../../features/task/components/TaskForm';
 import { getNotifier } from '../di/notifierDI';
 import { getDailyMemoText } from '../../domain/memo';
 import { isVisibleInWeek } from '../../domain/schedule/scheduleLimit';
+import { getRunningTaskId } from '../../domain/timeTracking/timer';
 
 export function useAppModel() {
   const {
@@ -60,14 +61,11 @@ export function useAppModel() {
   const todayDow = dayOfWeek(today);
   const weekStartYmd = toYmd(startOfWeekMonday(today));
 
-  // Single running timer (today). Store enforces 1 running entry per day.
-  // (role: single running task id for today, type: string | null)
-  const runningTaskIdToday = useMemo(() => {
-    const running = timeEntries.find(
-      (e) => e.date === todayYmd && e.endedAt == null,
-    );
-    return running?.taskId ?? null;
-  }, [timeEntries, todayYmd]);
+  // Single running timer. Keep entries started before midnight controllable.
+  // (role: single running task id, type: string | null)
+  const runningTaskId = useMemo(() => {
+    return getRunningTaskId(timeEntries);
+  }, [timeEntries]);
 
   const weekStats = useMemo(
     () => calcWeekStats(tasks, completions, weekStartYmd),
@@ -222,7 +220,7 @@ export function useAppModel() {
     todayYmd,
     todayDow,
     nowIso,
-    runningTaskIdToday,
+    runningTaskId,
 
     // view state
     tab,

--- a/apps/desktop/src/app/hooks/useAppModel.ts
+++ b/apps/desktop/src/app/hooks/useAppModel.ts
@@ -76,10 +76,13 @@ export function useAppModel() {
     const filtered = tasks.filter((t) => {
       if (!t.isActive) return false;
 
+      const isRunning = runningTaskId === t.id;
       const createdAtYmd = t.createdAt.slice(0, 10);
       const startYmd = t.startYmd?.trim() || null;
       const effectiveStartYmd =
         startYmd && startYmd > createdAtYmd ? startYmd : createdAtYmd;
+      // Keep an active timer visible after midnight so it can still be stopped.
+      if (isRunning) return true;
       if (todayYmd < effectiveStartYmd) return false;
 
       const doneToday = completions.some(
@@ -97,7 +100,7 @@ export function useAppModel() {
       if (aDone === bDone) return 0;
       return aDone ? 1 : -1;
     });
-  }, [tasks, completions, todayDow, todayYmd, weekStartYmd]);
+  }, [tasks, completions, runningTaskId, todayDow, todayYmd, weekStartYmd]);
 
   const todayStats = useMemo(
     () => calcTodayStats(todayTasks, completions, todayYmd, todayDow),

--- a/apps/desktop/src/app/pages/ManagePage.tsx
+++ b/apps/desktop/src/app/pages/ManagePage.tsx
@@ -18,7 +18,7 @@ export function ManagePage(props: {
   todayDow: DayOfWeek; // (role: day-of-week, type: DayOfWeek)
 
   nowIso: string; // (role: ui clock iso, type: string)
-  runningTaskIdToday: string | null; // (role: single running task id, type: string | null)
+  runningTaskId: string | null; // (role: single running task id, type: string | null)
 
   manageQuery: string; // (role: search query, type: string)
   setManageQuery: (v: string) => void; // (role: set query, type: (string)=>void)
@@ -56,7 +56,7 @@ export function ManagePage(props: {
     todayYmd,
     todayDow,
     nowIso,
-    runningTaskIdToday,
+    runningTaskId,
     manageQuery,
     setManageQuery,
     manageCategory,
@@ -195,7 +195,7 @@ export function ManagePage(props: {
             todayYmd={todayYmd}
             todayDow={todayDow}
             nowIso={nowIso}
-            runningTaskIdToday={runningTaskIdToday}
+            runningTaskId={runningTaskId}
             onUpdateTaskMeta={onUpdateTaskMeta}
             onToggleToday={onToggleToday}
             onArchive={onArchive}

--- a/apps/desktop/src/app/pages/SchedulePage.tsx
+++ b/apps/desktop/src/app/pages/SchedulePage.tsx
@@ -1,7 +1,7 @@
 import { useContext, useMemo, useState } from 'react';
 import clsx from 'clsx';
 import type { Completion, Task } from '../../shared/types';
-import { buildWeekSchedule, WEEK_ORDER } from '../../domain/scheduleView';
+import { buildWeekSchedule, WEEK_ORDER } from '../../domain/schedule/scheduleView';
 import {
   buildWeekDates,
   startOfWeekMonday,
@@ -238,17 +238,6 @@ export function SchedulePage(props: {
                           </div>
                         </div>
 
-                        {blocks >= 2 && (
-                          <div
-                            className={clsx(
-                              'mt-2 hidden text-xs lg:block',
-                              doneThatDay
-                                ? 'text-emerald-200/60'
-                                : 'text-zinc-600',
-                            )}>
-                            {/* room for future */}
-                          </div>
-                        )}
                       </button>
                     );
                   })}

--- a/apps/desktop/src/app/pages/TodayPage.tsx
+++ b/apps/desktop/src/app/pages/TodayPage.tsx
@@ -8,7 +8,7 @@ import type {
   TimeEntry,
 } from '../../shared/types';
 import type { TodayStats } from '../../domain/stats/stats';
-import { diffMinutes } from '../../shared/utils/date';
+import { getTrackedMinutes } from '../../domain/timeTracking';
 import { LocaleContext } from '../../i18n/context';
 
 // (role: clamp helper, type: (number, number, number)=>number)
@@ -95,20 +95,13 @@ export function TodayPage(props: {
 
   const todayTaskIdSet = new Set(todayTasks.map((t) => t.id));
 
-  const doneTaskIdSet = new Set(
-    (completions ?? [])
-      .filter((c) => c.date === todayYmd && todayTaskIdSet.has(c.taskId))
-      .map((c) => c.taskId),
-  );
-
   const measuredByTaskId = new Map<string, number>();
 
   (timeEntries ?? []).forEach((e) => {
     if (e.date !== todayYmd) return;
     if (!todayTaskIdSet.has(e.taskId)) return;
 
-    const minutes =
-      e.endedAt == null ? diffMinutes(e.startedAt, nowIso) : e.minutes || 0;
+    const minutes = getTrackedMinutes(e, nowIso);
 
     measuredByTaskId.set(
       e.taskId,
@@ -116,11 +109,10 @@ export function TodayPage(props: {
     );
   });
 
-  const spentMinutesToday = todayTasks.reduce((acc, t) => {
-    const planned = Math.max(0, t.durationMinutes || 0);
-    if (doneTaskIdSet.has(t.id)) return acc + planned;
-    return acc + (measuredByTaskId.get(t.id) || 0);
-  }, 0);
+  const spentMinutesToday = todayTasks.reduce(
+    (acc, t) => acc + (measuredByTaskId.get(t.id) || 0),
+    0,
+  );
 
   const timeProgressPct =
     plannedMinutesToday <= 0

--- a/apps/desktop/src/app/pages/TodayPage.tsx
+++ b/apps/desktop/src/app/pages/TodayPage.tsx
@@ -55,7 +55,7 @@ export function TodayPage(props: {
   timeEntries: TimeEntry[]; // (role: time tracking logs, type: TimeEntry[])
 
   nowIso: string; // (role: ui clock iso, type: string)
-  runningTaskIdToday: string | null; // (role: single running task id, type: string | null)
+  runningTaskId: string | null; // (role: single running task id, type: string | null)
 
   getMemoText: (taskId: string, date: string) => string;
   onSaveMemo: (input: { taskId: string; date: string; text: string }) => void;
@@ -78,7 +78,7 @@ export function TodayPage(props: {
     completions,
     timeEntries,
     nowIso,
-    runningTaskIdToday,
+    runningTaskId,
     getMemoText,
     onSaveMemo,
     onToggleToday,
@@ -233,7 +233,7 @@ export function TodayPage(props: {
             todayYmd={todayYmd}
             todayDow={todayDow}
             nowIso={nowIso}
-            runningTaskIdToday={runningTaskIdToday}
+            runningTaskId={runningTaskId}
             getMemoText={getMemoText}
             onSaveMemo={onSaveMemo}
             onToggleToday={onToggleToday}

--- a/apps/desktop/src/app/pages/TodayPage.tsx
+++ b/apps/desktop/src/app/pages/TodayPage.tsx
@@ -88,7 +88,11 @@ export function TodayPage(props: {
     onError,
   } = props;
 
-  const plannedMinutesToday = todayTasks.reduce(
+  const scheduledTodayTasks = todayTasks.filter((task) =>
+    task.daysOfWeek.includes(todayDow),
+  );
+
+  const plannedMinutesToday = scheduledTodayTasks.reduce(
     (acc, t) => acc + Math.max(0, t.durationMinutes || 0),
     0,
   );

--- a/apps/desktop/src/app/store/useFrilDayStore.ts
+++ b/apps/desktop/src/app/store/useFrilDayStore.ts
@@ -16,6 +16,10 @@ import {
 import { createTaskEntity } from '../../domain/task/taskFactory';
 import { getNotifier } from '../di/notifierDI';
 import { upsertDailyMemo } from '../../domain/memo';
+import {
+  autoStopEntriesAtTarget,
+  closeRunningEntries,
+} from '../../domain/timeTracking/timer';
 
 export type Filter = 'all' | Category;
 
@@ -62,7 +66,7 @@ interface FrilDayState {
   setDailyMemo: (input: { taskId: string; date: string; text: string }) => void;
   startTimer: (input: { taskId: string; today: Date }) => void;
   stopTimer: (input: { taskId: string; today: Date }) => void;
-  autoStopIfReached: (input: { today: Date }) => string[];
+  autoStopIfReached: () => string[];
 }
 
 function uid(): string {
@@ -314,14 +318,9 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
       (c) => c.taskId === taskId && c.date === date,
     );
 
-    let nextTimeEntries = get().timeEntries;
     let nextTasks = get().tasks;
 
-    if (wasDone) {
-      nextTimeEntries = nextTimeEntries.filter(
-        (e) => !(e.taskId === taskId && e.date === date),
-      );
-    } else {
+    if (!wasDone) {
       const toggledTask = nextTasks.find((t) => t.id === taskId);
       if (
         toggledTask &&
@@ -343,14 +342,14 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
     const next = {
       tasks: nextTasks,
       completions: nextCompletions,
-      timeEntries: nextTimeEntries,
+      timeEntries: get().timeEntries,
       taskDailyMemos: get().taskDailyMemos,
     };
 
     set({
       tasks: nextTasks,
       completions: nextCompletions,
-      timeEntries: nextTimeEntries,
+      timeEntries: get().timeEntries,
       errorMsg: '',
     });
     persistCollections(next, 'Failed to update completion.');
@@ -381,20 +380,14 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
 
     const entries = get().timeEntries;
     const alreadyRunningSameTask = entries.some(
-      (e) => e.taskId === taskId && e.date === date && e.endedAt == null,
+      (e) => e.taskId === taskId && e.endedAt == null,
     );
     if (alreadyRunningSameTask) {
       set({ errorMsg: 'Timer is already running for this task today.' });
       return;
     }
 
-    const nextTimeEntries = entries.map((e) => {
-      if (e.date !== date) return e;
-      if (e.endedAt != null) return e;
-
-      const minutes = diffMinutes(e.startedAt, nowIso);
-      return { ...e, endedAt: nowIso, minutes };
-    });
+    const nextTimeEntries = closeRunningEntries(entries, nowIso);
 
     const entry: TimeEntry = {
       id: uid(),
@@ -420,7 +413,7 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
     const date = toYmd(today);
 
     const idx = get().timeEntries.findIndex(
-      (e) => e.taskId === taskId && e.date === date && e.endedAt == null,
+      (e) => e.taskId === taskId && e.date <= date && e.endedAt == null,
     );
     if (idx === -1) {
       set({ errorMsg: 'No running timer for this task today.' });
@@ -446,84 +439,48 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
     persistCollections(next, 'Failed to stop timer.');
   },
 
-  autoStopIfReached: ({ today }) => {
+  autoStopIfReached: () => {
     if (!get().hydrated) return [];
 
-    const date = toYmd(today);
     const nowIso = new Date().toISOString();
+    const result = autoStopEntriesAtTarget(
+      get().timeEntries,
+      get().tasks,
+      get().completions,
+      nowIso,
+    );
 
-    const entries = get().timeEntries;
-    const tasks = get().tasks;
+    if (result.finishedTasks.length === 0) return [];
 
-    const nextEntries = [...entries];
-    const nextCompletions = [...get().completions];
-    const finishedTaskTitles: string[] = [];
-    let changed = false;
+    const notifier = getNotifier();
+    for (const finishedTask of result.finishedTasks) {
+      notifier.notify({
+        level: 'info',
+        message: `Auto-stopped: ${finishedTask.title} (+${finishedTask.minutes}m)`,
+      });
 
-    for (let i = 0; i < nextEntries.length; i += 1) {
-      const e = nextEntries[i];
-
-      if (e.date !== date) continue;
-      if (e.endedAt != null) continue;
-
-      const task = tasks.find((t) => t.id === e.taskId);
-      if (!task) continue;
-
-      const doneMinutes = nextEntries
-        .filter(
-          (x) =>
-            x.taskId === e.taskId &&
-            x.date === date &&
-            x.endedAt != null &&
-            Number.isFinite(x.minutes),
-        )
-        .reduce((acc, x) => acc + (x.minutes || 0), 0);
-
-      const runningMinutes = diffMinutes(e.startedAt, nowIso);
-      const total = doneMinutes + runningMinutes;
-
-      if (total >= task.durationMinutes) {
-        nextEntries[i] = { ...e, endedAt: nowIso, minutes: runningMinutes };
-        finishedTaskTitles.push(task.title);
-        changed = true;
-
-        const notifier = getNotifier();
+      if (finishedTask.autoCompleted) {
         notifier.notify({
-          level: 'info',
-          message: `Auto-stopped: ${task.title} (+${runningMinutes}m)`,
+          level: 'success',
+          message: `Auto-completed: ${finishedTask.title}`,
         });
-
-        const alreadyDone = nextCompletions.some(
-          (c) => c.taskId === e.taskId && c.date === date,
-        );
-
-        if (!alreadyDone) {
-          nextCompletions.push({ taskId: e.taskId, date });
-
-          notifier.notify({
-            level: 'success',
-            message: `Auto-completed: ${task.title}`,
-          });
-        }
       }
     }
 
-    if (!changed) return [];
-
     const next = {
       tasks: get().tasks,
-      completions: nextCompletions,
-      timeEntries: nextEntries,
+      completions: result.completions,
+      timeEntries: result.timeEntries,
       taskDailyMemos: get().taskDailyMemos,
     };
 
     set({
-      timeEntries: nextEntries,
-      completions: nextCompletions,
+      timeEntries: result.timeEntries,
+      completions: result.completions,
       errorMsg: '',
     });
     persistCollections(next, 'Failed to auto-stop timer.');
 
-    return finishedTaskTitles;
+    return result.finishedTasks.map((finishedTask) => finishedTask.title);
   },
 }));

--- a/apps/desktop/src/domain/scheduleLimit.ts
+++ b/apps/desktop/src/domain/scheduleLimit.ts
@@ -1,1 +1,0 @@
-export * from './schedule/scheduleLimit';

--- a/apps/desktop/src/domain/scheduleView.ts
+++ b/apps/desktop/src/domain/scheduleView.ts
@@ -1,1 +1,0 @@
-export * from './schedule/scheduleView';

--- a/apps/desktop/src/domain/timeTracking/index.ts
+++ b/apps/desktop/src/domain/timeTracking/index.ts
@@ -1,0 +1,1 @@
+export * from './timeTracking';

--- a/apps/desktop/src/domain/timeTracking/timeTracking.ts
+++ b/apps/desktop/src/domain/timeTracking/timeTracking.ts
@@ -1,0 +1,46 @@
+import type { TimeEntry } from '../../shared/types';
+import { diffMinutes } from '../../shared/utils/date';
+
+function normalizedStoredMinutes(minutes: number): number {
+  if (!Number.isFinite(minutes)) return 0;
+  return Math.max(0, Math.floor(minutes));
+}
+
+// (role: calculate one entry's current or persisted duration, type: (TimeEntry, string)=>number)
+export function getTrackedMinutes(entry: TimeEntry, nowIso: string): number {
+  if (entry.endedAt == null) {
+    return diffMinutes(entry.startedAt, nowIso);
+  }
+
+  return normalizedStoredMinutes(entry.minutes);
+}
+
+// (role: calculate actual minutes for one task on one date, type: (TimeEntry[], string, string, string)=>number)
+export function totalTrackedMinutes(
+  entries: TimeEntry[],
+  taskId: string,
+  dateYmd: string,
+  nowIso: string,
+): number {
+  return entries
+    .filter((entry) => entry.taskId === taskId && entry.date === dateYmd)
+    .reduce((total, entry) => total + getTrackedMinutes(entry, nowIso), 0);
+}
+
+// (role: aggregate actual minutes by task for one date, type: (TimeEntry[], string, string)=>Map)
+export function trackedMinutesByTask(
+  entries: TimeEntry[],
+  dateYmd: string,
+  nowIso: string,
+): Map<string, number> {
+  const totals = new Map<string, number>();
+
+  for (const entry of entries) {
+    if (entry.date !== dateYmd) continue;
+
+    const current = totals.get(entry.taskId) ?? 0;
+    totals.set(entry.taskId, current + getTrackedMinutes(entry, nowIso));
+  }
+
+  return totals;
+}

--- a/apps/desktop/src/domain/timeTracking/timer.ts
+++ b/apps/desktop/src/domain/timeTracking/timer.ts
@@ -1,0 +1,88 @@
+import type { Completion, Task, TimeEntry } from '../../shared/types';
+import { diffMinutes } from '../../shared/utils/date';
+
+export interface AutoStopResult {
+  timeEntries: TimeEntry[];
+  completions: Completion[];
+  finishedTasks: Array<{
+    taskId: string;
+    title: string;
+    minutes: number;
+    autoCompleted: boolean;
+  }>;
+}
+
+// (role: close every active entry at one timestamp, type: (TimeEntry[], string)=>TimeEntry[])
+export function closeRunningEntries(
+  entries: TimeEntry[],
+  endedAt: string,
+): TimeEntry[] {
+  return entries.map((entry) => {
+    if (entry.endedAt != null) return entry;
+
+    return {
+      ...entry,
+      endedAt,
+      minutes: diffMinutes(entry.startedAt, endedAt),
+    };
+  });
+}
+
+// (role: stop entries that have reached their planned duration, type: pure timer transition)
+export function autoStopEntriesAtTarget(
+  entries: TimeEntry[],
+  tasks: Task[],
+  completions: Completion[],
+  nowIso: string,
+): AutoStopResult {
+  const nextEntries = [...entries];
+  const nextCompletions = [...completions];
+  const finishedTasks: AutoStopResult['finishedTasks'] = [];
+
+  for (let i = 0; i < nextEntries.length; i += 1) {
+    const entry = nextEntries[i];
+    if (!entry || entry.endedAt != null) continue;
+
+    const task = tasks.find((candidate) => candidate.id === entry.taskId);
+    if (!task) continue;
+
+    const completedMinutes = nextEntries
+      .filter(
+        (candidate) =>
+          candidate.taskId === entry.taskId &&
+          candidate.date === entry.date &&
+          candidate.endedAt != null &&
+          Number.isFinite(candidate.minutes),
+      )
+      .reduce((total, candidate) => total + Math.max(0, candidate.minutes), 0);
+    const runningMinutes = diffMinutes(entry.startedAt, nowIso);
+
+    if (completedMinutes + runningMinutes < task.durationMinutes) continue;
+
+    nextEntries[i] = {
+      ...entry,
+      endedAt: nowIso,
+      minutes: runningMinutes,
+    };
+    let autoCompleted = false;
+
+    if (
+      !nextCompletions.some(
+        (completion) =>
+          completion.taskId === entry.taskId && completion.date === entry.date,
+      )
+    ) {
+      nextCompletions.push({ taskId: entry.taskId, date: entry.date });
+      autoCompleted = true;
+    }
+
+    finishedTasks.push({
+      taskId: entry.taskId,
+      title: task.title,
+      minutes: runningMinutes,
+      autoCompleted,
+    });
+  }
+
+  return { timeEntries: nextEntries, completions: nextCompletions, finishedTasks };
+}

--- a/apps/desktop/src/domain/timeTracking/timer.ts
+++ b/apps/desktop/src/domain/timeTracking/timer.ts
@@ -12,6 +12,10 @@ export interface AutoStopResult {
   }>;
 }
 
+export function getRunningTaskId(entries: TimeEntry[]): string | null {
+  return entries.find((entry) => entry.endedAt == null)?.taskId ?? null;
+}
+
 // (role: close every active entry at one timestamp, type: (TimeEntry[], string)=>TimeEntry[])
 export function closeRunningEntries(
   entries: TimeEntry[],

--- a/apps/desktop/src/features/statistics/components/PeriodStatsPanel.tsx
+++ b/apps/desktop/src/features/statistics/components/PeriodStatsPanel.tsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 import type { Completion, Task } from '../types';
-import { dayOfWeek } from '../date';
+import { dayOfWeek } from '../../../shared/utils/date';
 import { isScheduledOn } from '../../../domain/schedule';
 import { isDoneOn } from '../../../domain/completion';
 import { LocaleContext } from '../../../i18n/context';

--- a/apps/desktop/src/features/statistics/date.ts
+++ b/apps/desktop/src/features/statistics/date.ts
@@ -1,1 +1,0 @@
-export * from '../../shared/utils/date';

--- a/apps/desktop/src/features/task/components/TaskForm.tsx
+++ b/apps/desktop/src/features/task/components/TaskForm.tsx
@@ -6,7 +6,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import type { Category, DayOfWeek } from '../types';
 import { ALL_DAYS } from '../../../domain/schedule';
 import { LocaleContext } from '../../../i18n/context';
-import { toYmd } from '../date';
+import { toYmd } from '../../../shared/utils/date';
 
 // (role: zod enum sources, type: readonly arrays)
 const CATEGORY_VALUES = [

--- a/apps/desktop/src/features/task/components/TaskList.tsx
+++ b/apps/desktop/src/features/task/components/TaskList.tsx
@@ -11,7 +11,7 @@ interface TaskListProps {
   todayDow: DayOfWeek;
 
   nowIso: string; // (role: ui clock iso, type: string)
-  runningTaskIdToday: string | null; // (role: single running task id, type: string | null)
+  runningTaskId: string | null; // (role: single running task id, type: string | null)
 
   getMemoText?: (taskId: string, date: string) => string;
 
@@ -59,7 +59,7 @@ export function TaskList(props: TaskListProps) {
           todayYmd={props.todayYmd}
           todayDow={props.todayDow}
           nowIso={props.nowIso}
-          runningTaskIdToday={props.runningTaskIdToday}
+          runningTaskId={props.runningTaskId}
           variant={props.variant}
           onToggleToday={props.onToggleToday}
           onArchive={props.onArchive}

--- a/apps/desktop/src/features/task/components/TaskListItem.tsx
+++ b/apps/desktop/src/features/task/components/TaskListItem.tsx
@@ -2,7 +2,7 @@ import { useContext, useState } from 'react';
 import type { Completion, DayOfWeek, Task, TimeEntry } from '../types';
 import { isDoneOn } from '../../../domain/completion';
 import { isScheduledOn } from '../../../domain/schedule';
-import { diffMinutes } from '../date';
+import { totalTrackedMinutes } from '../../../domain/timeTracking';
 import { Archive, Check, Pause, Pencil, Play, StickyNote } from 'lucide-react';
 import clsx from 'clsx';
 import { LocaleContext } from '../../../i18n/context';
@@ -79,24 +79,23 @@ export function TaskListItem(props: TaskListItemProps) {
       : `(${Math.min(doneCountTotal, task.autoArchiveAfter)}/${task.autoArchiveAfter})`;
 
   const safeTimeEntries = timeEntries ?? [];
-  const todayEntries = safeTimeEntries.filter(
-    (e) => e.taskId === task.id && e.date === todayYmd,
-  );
 
-  // Store policy: only ONE running entry per day.
+  // Store policy: only ONE running entry is active at a time.
   const running = runningTaskIdToday === task.id;
 
-  const totalMinutesToday = todayEntries.reduce((acc, e) => {
-    if (e.endedAt == null) return acc + diffMinutes(e.startedAt, nowIso);
-    return acc + (e.minutes || 0);
-  }, 0);
+  const totalMinutesToday = totalTrackedMinutes(
+    safeTimeEntries,
+    task.id,
+    todayYmd,
+    nowIso,
+  );
 
   const plannedMinutes = Math.max(0, task.durationMinutes || 0);
 
-  // progress (0~1). if done => 1 (UX)
-  const progress01 = doneToday
-    ? 1
-    : plannedMinutes === 0
+  // Completion and tracked time are independent. A manual completion must not
+  // make the actual-time progress look like the planned time was spent.
+  const progress01 =
+    plannedMinutes === 0
       ? 0
       : Math.min(totalMinutesToday / plannedMinutes, 1);
 
@@ -233,7 +232,7 @@ export function TaskListItem(props: TaskListItemProps) {
             <span
               className={clsx(variant == 'today' ? 'inline-block' : 'hidden')}>
               · {tr('task.todaySpent')}:{' '}
-              {doneToday ? task.durationMinutes : totalMinutesToday}
+              {totalMinutesToday}
               {tr('time.minuteShort')}
             </span>
             {task.autoArchiveAfter != null && (

--- a/apps/desktop/src/features/task/components/TaskListItem.tsx
+++ b/apps/desktop/src/features/task/components/TaskListItem.tsx
@@ -276,14 +276,17 @@ export function TaskListItem(props: TaskListItemProps) {
             <button
               type="button"
               onClick={() => {
+                if (running) {
+                  onStopTimer(task);
+                  return;
+                }
                 if (!scheduledToday) {
                   onError(tr('note.taskNotScheduledToday'));
                   return;
                 }
-                if (running) onStopTimer(task);
-                else onStartTimer(task);
+                onStartTimer(task);
               }}
-              disabled={!scheduledToday || doneToday}
+              disabled={(!scheduledToday && !running) || (doneToday && !running)}
               className={[
                 'rounded-xl border px-3 py-2 text-sm transition min-w-18 shrink-0',
                 running

--- a/apps/desktop/src/features/task/components/TaskListItem.tsx
+++ b/apps/desktop/src/features/task/components/TaskListItem.tsx
@@ -15,7 +15,7 @@ interface TaskListItemProps {
   todayDow: DayOfWeek; // (role: day-of-week, type: DayOfWeek)
 
   nowIso: string; // (role: ui clock iso, type: string)
-  runningTaskIdToday: string | null; // (role: single running task id, type: string | null)
+  runningTaskId: string | null; // (role: single running task id, type: string | null)
 
   variant: 'today' | 'manage'; // (role: UI behavior switch, type: union)
   memoText?: string; // (role: today memo text, type: string | undefined)
@@ -47,7 +47,7 @@ export function TaskListItem(props: TaskListItemProps) {
     todayYmd,
     todayDow,
     nowIso,
-    runningTaskIdToday,
+    runningTaskId,
     variant,
     memoText,
     onToggleToday,
@@ -81,7 +81,7 @@ export function TaskListItem(props: TaskListItemProps) {
   const safeTimeEntries = timeEntries ?? [];
 
   // Store policy: only ONE running entry is active at a time.
-  const running = runningTaskIdToday === task.id;
+  const running = runningTaskId === task.id;
 
   const totalMinutesToday = totalTrackedMinutes(
     safeTimeEntries,

--- a/apps/desktop/src/features/task/date.ts
+++ b/apps/desktop/src/features/task/date.ts
@@ -1,1 +1,0 @@
-export * from '../../shared/utils/date';

--- a/apps/desktop/src/features/task/hooks/useAutoStopTick.ts
+++ b/apps/desktop/src/features/task/hooks/useAutoStopTick.ts
@@ -17,7 +17,7 @@ export function useAutoStopTick() {
     const id = window.setInterval(() => {
       const finishedTaskTitles = useFrilDayStore
         .getState()
-        .autoStopIfReached({ today: new Date() });
+        .autoStopIfReached();
 
       if (finishedTaskTitles.length === 0) return;
 

--- a/apps/desktop/src/infrastructure/storage/index.ts
+++ b/apps/desktop/src/infrastructure/storage/index.ts
@@ -11,7 +11,7 @@ import type {
   TaskDailyMemo,
   TimeEntry,
 } from '../../shared/types';
-import { appDb } from '../tauri/db';
+import { appDb, type SqlStatement } from '../tauri/db';
 import { isTauri } from '../tauri/runtime';
 
 // These keys are persisted data identifiers. Keep them stable unless an
@@ -201,103 +201,120 @@ async function hasExistingData(): Promise<boolean> {
   );
 }
 
-async function replaceTasks(tasks: Task[]): Promise<void> {
-  await appDb.execute('DELETE FROM tasks');
-
-  for (const task of tasks) {
-    await appDb.execute(
-      `
-        INSERT INTO tasks (
-          id,
-          title,
-          description,
-          category,
-          days_of_week,
-          duration_minutes,
-          start_ymd,
-          auto_archive_after,
-          repeat_count,
-          is_active,
-          created_at
-        )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `,
-      [
-        task.id,
-        task.title,
-        task.description,
-        task.category,
-        JSON.stringify(task.daysOfWeek),
-        task.durationMinutes,
-        task.startYmd ?? null,
-        task.autoArchiveAfter ?? null,
-        task.repeatCount ?? null,
-        task.isActive ? 1 : 0,
-        task.createdAt,
-      ],
-    );
-  }
+function statement(sql: string, bind: unknown[] = []): SqlStatement {
+  return { sql, bind };
 }
 
-async function replaceCompletions(completions: Completion[]): Promise<void> {
-  await appDb.execute('DELETE FROM completions');
-
-  for (const completion of completions) {
-    await appDb.execute(
-      'INSERT INTO completions (task_id, date) VALUES (?, ?)',
-      [completion.taskId, completion.date],
-    );
-  }
+function buildTaskStatements(tasks: Task[]): SqlStatement[] {
+  return [
+    statement('DELETE FROM tasks'),
+    ...tasks.map((task) =>
+      statement(
+        `
+          INSERT INTO tasks (
+            id,
+            title,
+            description,
+            category,
+            days_of_week,
+            duration_minutes,
+            start_ymd,
+            auto_archive_after,
+            repeat_count,
+            is_active,
+            created_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `,
+        [
+          task.id,
+          task.title,
+          task.description,
+          task.category,
+          JSON.stringify(task.daysOfWeek),
+          task.durationMinutes,
+          task.startYmd ?? null,
+          task.autoArchiveAfter ?? null,
+          task.repeatCount ?? null,
+          task.isActive ? 1 : 0,
+          task.createdAt,
+        ],
+      ),
+    ),
+  ];
 }
 
-async function replaceTimeEntries(timeEntries: TimeEntry[]): Promise<void> {
-  await appDb.execute('DELETE FROM time_entries');
-
-  for (const entry of timeEntries) {
-    await appDb.execute(
-      `
-        INSERT INTO time_entries (
-          id,
-          task_id,
-          date,
-          started_at,
-          ended_at,
-          minutes
-        )
-        VALUES (?, ?, ?, ?, ?, ?)
-      `,
-      [
-        entry.id,
-        entry.taskId,
-        entry.date,
-        entry.startedAt,
-        entry.endedAt,
-        entry.minutes,
-      ],
-    );
-  }
+function buildCompletionStatements(
+  completions: Completion[],
+): SqlStatement[] {
+  return [
+    statement('DELETE FROM completions'),
+    ...completions.map((completion) =>
+      statement('INSERT INTO completions (task_id, date) VALUES (?, ?)', [
+        completion.taskId,
+        completion.date,
+      ]),
+    ),
+  ];
 }
 
-async function replaceTaskDailyMemos(
-  taskDailyMemos: TaskDailyMemo[],
-): Promise<void> {
-  await appDb.execute('DELETE FROM task_daily_memos');
+function buildTimeEntryStatements(timeEntries: TimeEntry[]): SqlStatement[] {
+  return [
+    statement('DELETE FROM time_entries'),
+    ...timeEntries.map((entry) =>
+      statement(
+        `
+          INSERT INTO time_entries (
+            id,
+            task_id,
+            date,
+            started_at,
+            ended_at,
+            minutes
+          )
+          VALUES (?, ?, ?, ?, ?, ?)
+        `,
+        [
+          entry.id,
+          entry.taskId,
+          entry.date,
+          entry.startedAt,
+          entry.endedAt,
+          entry.minutes,
+        ],
+      ),
+    ),
+  ];
+}
 
-  for (const memo of taskDailyMemos) {
-    await appDb.execute(
-      `
-        INSERT INTO task_daily_memos (
-          id,
-          task_id,
-          date,
-          text,
-          updated_at
-        )
-        VALUES (?, ?, ?, ?, ?)
-      `,
-      [memo.id, memo.taskId, memo.date, memo.text, memo.updatedAt],
-    );
-  }
+function buildMemoStatements(taskDailyMemos: TaskDailyMemo[]): SqlStatement[] {
+  return [
+    statement('DELETE FROM task_daily_memos'),
+    ...taskDailyMemos.map((memo) =>
+      statement(
+        `
+          INSERT INTO task_daily_memos (
+            id,
+            task_id,
+            date,
+            text,
+            updated_at
+          )
+          VALUES (?, ?, ?, ?, ?)
+        `,
+        [memo.id, memo.taskId, memo.date, memo.text, memo.updatedAt],
+      ),
+    ),
+  ];
+}
+
+function buildSnapshotStatements(data: PersistedAppData): SqlStatement[] {
+  return [
+    ...buildTaskStatements(data.tasks),
+    ...buildCompletionStatements(data.completions),
+    ...buildTimeEntryStatements(data.timeEntries),
+    ...buildMemoStatements(data.taskDailyMemos),
+  ];
 }
 
 let writeQueue: Promise<void> = Promise.resolve();
@@ -312,22 +329,7 @@ async function saveAppData(data: PersistedAppData): Promise<void> {
   if (!isTauri()) return;
 
   await appDb.init();
-  await appDb.execute('BEGIN TRANSACTION');
-
-  try {
-    await replaceTasks(data.tasks);
-    await replaceCompletions(data.completions);
-    await replaceTimeEntries(data.timeEntries);
-    await replaceTaskDailyMemos(data.taskDailyMemos);
-    await appDb.execute('COMMIT');
-  } catch (error) {
-    try {
-      await appDb.execute('ROLLBACK');
-    } catch (rollbackError) {
-      console.error('Failed to roll back app data save', rollbackError);
-    }
-    throw error;
-  }
+  await appDb.executeTransaction(buildSnapshotStatements(data));
 }
 
 function loadLegacyAppData(): LegacyAppData {

--- a/apps/desktop/src/infrastructure/storage/index.ts
+++ b/apps/desktop/src/infrastructure/storage/index.ts
@@ -17,6 +17,7 @@ import { isTauri } from '../tauri/runtime';
 // These keys are persisted data identifiers. Keep them stable unless an
 // explicit data migration accompanies a future rename.
 const STORAGE_KEYS = {
+  // These names are persisted legacy keys. Keep them stable for migration.
   tasks: 'dailycheck.tasks.v2',
   completions: 'dailycheck.completions.v1',
   timeEntries: 'dailycheck.timeEntries.v1',
@@ -30,6 +31,17 @@ type PersistedAppData = {
   completions: Completion[];
   timeEntries: TimeEntry[];
   taskDailyMemos: TaskDailyMemo[];
+};
+
+type LegacyCollection<T> = {
+  value: T;
+  valid: boolean;
+};
+
+type LegacyAppData = {
+  data: PersistedAppData;
+  valid: boolean;
+  hasData: boolean;
 };
 
 type MetaRow = {
@@ -74,15 +86,25 @@ type TaskDailyMemoRow = {
 
 function parseLegacyJson<T>(
   key: string,
-  parse: (value: unknown) => T,
+  schema: {
+    safeParse: (
+      value: unknown,
+    ) => { success: true; data: T } | { success: false };
+  },
   fallback: T,
-): T {
+): LegacyCollection<T> {
   try {
     const raw = localStorage.getItem(key);
-    if (!raw) return fallback;
-    return parse(JSON.parse(raw) as unknown);
+    if (raw == null) {
+      return { value: fallback, valid: true };
+    }
+
+    const result = schema.safeParse(JSON.parse(raw) as unknown);
+    return result.success
+      ? { value: result.data, valid: true }
+      : { value: fallback, valid: false };
   } catch {
-    return fallback;
+    return { value: fallback, valid: false };
   }
 }
 
@@ -278,50 +300,73 @@ async function replaceTaskDailyMemos(
   }
 }
 
+let writeQueue: Promise<void> = Promise.resolve();
+
+function enqueueWrite(operation: () => Promise<void>): Promise<void> {
+  const queued = writeQueue.then(operation, operation);
+  writeQueue = queued.catch(() => undefined);
+  return queued;
+}
+
 async function saveAppData(data: PersistedAppData): Promise<void> {
   if (!isTauri()) return;
 
   await appDb.init();
-  await replaceTasks(data.tasks);
-  await replaceCompletions(data.completions);
-  await replaceTimeEntries(data.timeEntries);
-  await replaceTaskDailyMemos(data.taskDailyMemos);
+  await appDb.execute('BEGIN TRANSACTION');
+
+  try {
+    await replaceTasks(data.tasks);
+    await replaceCompletions(data.completions);
+    await replaceTimeEntries(data.timeEntries);
+    await replaceTaskDailyMemos(data.taskDailyMemos);
+    await appDb.execute('COMMIT');
+  } catch (error) {
+    try {
+      await appDb.execute('ROLLBACK');
+    } catch (rollbackError) {
+      console.error('Failed to roll back app data save', rollbackError);
+    }
+    throw error;
+  }
 }
 
-function loadLegacyAppData(): PersistedAppData {
+function loadLegacyAppData(): LegacyAppData {
+  const tasks = parseLegacyJson(STORAGE_KEYS.tasks, TasksSchema, [] as Task[]);
+  const completions = parseLegacyJson(
+    STORAGE_KEYS.completions,
+    CompletionsSchema,
+    [] as Completion[],
+  );
+  const timeEntries = parseLegacyJson(
+    STORAGE_KEYS.timeEntries,
+    TimeEntriesSchema,
+    [] as TimeEntry[],
+  );
+  const taskDailyMemos = parseLegacyJson(
+    STORAGE_KEYS.taskDailyMemos,
+    TaskDailyMemosSchema,
+    [] as TaskDailyMemo[],
+  );
+
+  const data = {
+    tasks: tasks.value,
+    completions: completions.value,
+    timeEntries: timeEntries.value,
+    taskDailyMemos: taskDailyMemos.value,
+  };
+
   return {
-    tasks: parseLegacyJson(
-      STORAGE_KEYS.tasks,
-      (decoded) => {
-        const result = TasksSchema.safeParse(decoded);
-        return result.success ? (result.data as Task[]) : [];
-      },
-      [],
-    ),
-    completions: parseLegacyJson(
-      STORAGE_KEYS.completions,
-      (decoded) => {
-        const result = CompletionsSchema.safeParse(decoded);
-        return result.success ? (result.data as Completion[]) : [];
-      },
-      [],
-    ),
-    timeEntries: parseLegacyJson(
-      STORAGE_KEYS.timeEntries,
-      (decoded) => {
-        const result = TimeEntriesSchema.safeParse(decoded);
-        return result.success ? (result.data as TimeEntry[]) : [];
-      },
-      [],
-    ),
-    taskDailyMemos: parseLegacyJson(
-      STORAGE_KEYS.taskDailyMemos,
-      (decoded) => {
-        const result = TaskDailyMemosSchema.safeParse(decoded);
-        return result.success ? (result.data as TaskDailyMemo[]) : [];
-      },
-      [],
-    ),
+    data,
+    valid:
+      tasks.valid &&
+      completions.valid &&
+      timeEntries.valid &&
+      taskDailyMemos.valid,
+    hasData:
+      tasks.value.length > 0 ||
+      completions.value.length > 0 ||
+      timeEntries.value.length > 0 ||
+      taskDailyMemos.value.length > 0,
   };
 }
 
@@ -341,21 +386,22 @@ async function migrateLegacyStorageIfNeeded(): Promise<void> {
     return;
   }
 
+  const legacyData = loadLegacyAppData();
+  if (!legacyData.valid) {
+    console.error(
+      'Legacy app data is invalid; leaving it untouched for recovery.',
+    );
+    return;
+  }
+
   if (await hasExistingData()) {
     await setMeta(LEGACY_STORAGE_MIGRATION_KEY, '1');
     clearLegacyAppData();
     return;
   }
 
-  const legacyData = loadLegacyAppData();
-  const hasLegacyData =
-    legacyData.tasks.length > 0 ||
-    legacyData.completions.length > 0 ||
-    legacyData.timeEntries.length > 0 ||
-    legacyData.taskDailyMemos.length > 0;
-
-  if (hasLegacyData) {
-    await saveAppData(legacyData);
+  if (legacyData.hasData) {
+    await saveAppData(legacyData.data);
   }
 
   clearLegacyAppData();
@@ -440,48 +486,46 @@ export async function loadAppData(): Promise<PersistedAppData> {
 }
 
 export async function saveTasks(tasks: Task[]): Promise<void> {
-  await saveAppData({
-    tasks,
-    completions: await loadCompletions(),
-    timeEntries: await loadTimeEntries(),
-    taskDailyMemos: await loadTaskDailyMemos(),
+  return enqueueWrite(async () => {
+    await migrateLegacyStorageIfNeeded();
+    const current = await loadAppData();
+    await saveAppData({ ...current, tasks });
   });
 }
 
 export async function saveCompletions(
   completions: Completion[],
 ): Promise<void> {
-  await saveAppData({
-    tasks: await loadTasks(),
-    completions,
-    timeEntries: await loadTimeEntries(),
-    taskDailyMemos: await loadTaskDailyMemos(),
+  return enqueueWrite(async () => {
+    await migrateLegacyStorageIfNeeded();
+    const current = await loadAppData();
+    await saveAppData({ ...current, completions });
   });
 }
 
 export async function saveTimeEntries(timeEntries: TimeEntry[]): Promise<void> {
-  await saveAppData({
-    tasks: await loadTasks(),
-    completions: await loadCompletions(),
-    timeEntries,
-    taskDailyMemos: await loadTaskDailyMemos(),
+  return enqueueWrite(async () => {
+    await migrateLegacyStorageIfNeeded();
+    const current = await loadAppData();
+    await saveAppData({ ...current, timeEntries });
   });
 }
 
 export async function saveTaskDailyMemos(
   taskDailyMemos: TaskDailyMemo[],
 ): Promise<void> {
-  await saveAppData({
-    tasks: await loadTasks(),
-    completions: await loadCompletions(),
-    timeEntries: await loadTimeEntries(),
-    taskDailyMemos,
+  return enqueueWrite(async () => {
+    await migrateLegacyStorageIfNeeded();
+    const current = await loadAppData();
+    await saveAppData({ ...current, taskDailyMemos });
   });
 }
 
 export async function replaceAllAppData(data: PersistedAppData): Promise<void> {
-  await migrateLegacyStorageIfNeeded();
-  await saveAppData(data);
+  return enqueueWrite(async () => {
+    await migrateLegacyStorageIfNeeded();
+    await saveAppData(data);
+  });
 }
 
 export async function loadTasks(): Promise<Task[]> {

--- a/apps/desktop/src/infrastructure/tauri/db.ts
+++ b/apps/desktop/src/infrastructure/tauri/db.ts
@@ -6,9 +6,11 @@ export type AppDb = {
   select<T>(sql: string, bind?: unknown[]): Promise<T[]>;
 };
 
+// Keep the existing database filename; changing it would bypass the native migration.
 const DB_URL = 'sqlite:daily_check.db';
 
 let dbPromise: Promise<import('@tauri-apps/plugin-sql').default> | null = null;
+let initPromise: Promise<void> | null = null;
 
 async function getDatabase(): Promise<import('@tauri-apps/plugin-sql').default> {
   if (!isTauri()) {
@@ -24,9 +26,7 @@ async function getDatabase(): Promise<import('@tauri-apps/plugin-sql').default> 
   return dbPromise;
 }
 
-async function init(): Promise<void> {
-  if (!isTauri()) return;
-
+async function initializeSchema(): Promise<void> {
   const db = await getDatabase();
   await db.execute(
     `
@@ -100,6 +100,19 @@ async function init(): Promise<void> {
     `,
     [],
   );
+}
+
+async function init(): Promise<void> {
+  if (!isTauri()) return;
+
+  if (!initPromise) {
+    initPromise = initializeSchema().catch((error) => {
+      initPromise = null;
+      throw error;
+    });
+  }
+
+  await initPromise;
 }
 
 async function execute(sql: string, bind: unknown[] = []): Promise<void> {

--- a/apps/desktop/src/infrastructure/tauri/db.ts
+++ b/apps/desktop/src/infrastructure/tauri/db.ts
@@ -1,9 +1,16 @@
 import { isTauri } from './runtime';
+import { invoke } from '@tauri-apps/api/core';
+
+export type SqlStatement = {
+  sql: string;
+  bind: unknown[];
+};
 
 export type AppDb = {
   init(): Promise<void>;
   execute(sql: string, bind?: unknown[]): Promise<void>;
   select<T>(sql: string, bind?: unknown[]): Promise<T[]>;
+  executeTransaction(statements: SqlStatement[]): Promise<void>;
 };
 
 // Keep the existing database filename; changing it would bypass the native migration.
@@ -129,8 +136,15 @@ async function select<T>(sql: string, bind: unknown[] = []): Promise<T[]> {
   return db.select<T[]>(sql, bind);
 }
 
+async function executeTransaction(statements: SqlStatement[]): Promise<void> {
+  if (!isTauri()) return;
+
+  await invoke('execute_app_transaction', { statements });
+}
+
 export const appDb: AppDb = {
   init,
   execute,
   select,
+  executeTransaction,
 };

--- a/apps/desktop/src/infrastructure/tauri/store.ts
+++ b/apps/desktop/src/infrastructure/tauri/store.ts
@@ -58,13 +58,19 @@ async function writeSqlSetting(key: string, value: unknown): Promise<void> {
   );
 }
 
-function readLegacyStorageSetting<T>(key: string): T | null {
+type LegacySetting = {
+  value: unknown;
+  present: boolean;
+  valid: boolean;
+};
+
+function readLegacyStorageSetting(key: string): LegacySetting {
   try {
     const raw = localStorage.getItem(key);
-    if (raw == null) return null;
-    return JSON.parse(raw) as T;
+    if (raw == null) return { value: null, present: false, valid: true };
+    return { value: JSON.parse(raw) as unknown, present: true, valid: true };
   } catch {
-    return null;
+    return { value: null, present: true, valid: false };
   }
 }
 
@@ -79,6 +85,7 @@ async function migrateLegacySettingsIfNeeded(): Promise<void> {
   }
 
   let legacyStoreValues = new Map<string, unknown>();
+  let hasInvalidLegacyValue = false;
 
   try {
     const { load } = await import('@tauri-apps/plugin-store');
@@ -95,20 +102,29 @@ async function migrateLegacySettingsIfNeeded(): Promise<void> {
   }
 
   for (const key of LEGACY_SETTING_KEYS) {
+    const legacyLocalValue = readLegacyStorageSetting(key);
+    if (!legacyLocalValue.valid) {
+      hasInvalidLegacyValue = true;
+      continue;
+    }
+
     const existing = await readSqlSetting(key);
-    if (existing != null) continue;
 
     const legacyValue =
-      legacyStoreValues.get(key) ?? readLegacyStorageSetting<unknown>(key);
+      legacyStoreValues.get(key) ?? legacyLocalValue.value;
 
-    if (legacyValue != null) {
+    if (existing == null && legacyValue != null) {
       await writeSqlSetting(key, legacyValue);
     }
 
-    localStorage.removeItem(key);
+    if (legacyLocalValue.present) {
+      localStorage.removeItem(key);
+    }
   }
 
-  await setMeta(LEGACY_SETTINGS_MIGRATION_KEY, '1');
+  if (!hasInvalidLegacyValue) {
+    await setMeta(LEGACY_SETTINGS_MIGRATION_KEY, '1');
+  }
 }
 
 export async function getSetting<T>(key: string, fallback: T): Promise<T> {

--- a/apps/desktop/src/shared/schemas.ts
+++ b/apps/desktop/src/shared/schemas.ts
@@ -47,12 +47,25 @@ const RepeatCountSchema = z.preprocess((value) => {
   return num;
 }, z.number().int().min(1).nullable());
 
+const YmdSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/)
+  .refine((value) => {
+    const [year, month, day] = value.split('-').map(Number);
+    const date = new Date(Date.UTC(year, month - 1, day));
+    return (
+      date.getUTCFullYear() === year &&
+      date.getUTCMonth() === month - 1 &&
+      date.getUTCDate() === day
+    );
+  }, 'Invalid calendar date');
+
+const IsoTimestampSchema = z.string().datetime({ offset: true });
+
 const StartYmdSchema = z.preprocess((value) => {
   if (value === '' || value == null) return null;
-  if (typeof value !== 'string') return null;
-  const ymd = value.trim();
-  return /^\d{4}-\d{2}-\d{2}$/.test(ymd) ? ymd : null;
-}, z.string().regex(/^\d{4}-\d{2}-\d{2}$/).nullable());
+  return typeof value === 'string' ? value.trim() : value;
+}, YmdSchema.nullable());
 
 // (role: task schema, type: zod schema)
 export const TaskSchema = z.object({
@@ -66,7 +79,7 @@ export const TaskSchema = z.object({
   autoArchiveAfter: AutoArchiveAfterSchema.optional().default(null),
   repeatCount: RepeatCountSchema.optional().default(null),
   isActive: z.boolean(),
-  createdAt: z.string().min(1),
+  createdAt: IsoTimestampSchema,
 });
 
 // (role: task list schema, type: zod schema)
@@ -75,7 +88,7 @@ export const TasksSchema = z.array(TaskSchema);
 // (role: completion schema, type: zod schema)
 export const CompletionSchema = z.object({
   taskId: z.string().min(1),
-  date: z.string().min(1),
+  date: YmdSchema,
 });
 
 // (role: completions schema, type: zod schema)
@@ -85,14 +98,10 @@ export const CompletionsSchema = z.array(CompletionSchema);
 export const TimeEntrySchema = z.object({
   id: z.string().min(1),
   taskId: z.string().min(1),
-  date: z.string().min(1),
-  startedAt: z.string().min(1),
-  endedAt: z.string().nullable(),
-  minutes: z
-    .number()
-    .int()
-    .min(0)
-    .max(24 * 60),
+  date: YmdSchema,
+  startedAt: IsoTimestampSchema,
+  endedAt: IsoTimestampSchema.nullable(),
+  minutes: z.number().int().min(0),
 });
 
 // (role: time entry list schema, type: zod schema)
@@ -102,9 +111,9 @@ export const TimeEntriesSchema = z.array(TimeEntrySchema);
 export const TaskDailyMemoSchema = z.object({
   id: z.string().min(1),
   taskId: z.string().min(1),
-  date: z.string().min(1),
+  date: YmdSchema,
   text: z.string(),
-  updatedAt: z.string().min(1),
+  updatedAt: IsoTimestampSchema,
 });
 
 // (role: memo list schema, type: zod schema)

--- a/apps/desktop/src/shared/utils/date.ts
+++ b/apps/desktop/src/shared/utils/date.ts
@@ -50,6 +50,9 @@ export function buildWeekDates(weekStartYmd: string): string[] {
 export function diffMinutes(startIso: string, endIso: string): number {
   const start = new Date(startIso).getTime();
   const end = new Date(endIso).getTime();
+
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return 0;
+
   const ms = Math.max(0, end - start);
   return Math.floor(ms / 60000);
 }

--- a/apps/desktop/tests/domain.test.ts
+++ b/apps/desktop/tests/domain.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from 'bun:test';
+import { useDailyCheckStore } from '../src/app/store/useDailyCheckStore';
+import { toggleCompletion } from '../src/domain/completion';
+import { pickWeeklySlots } from '../src/domain/schedule/scheduleLimit';
+import {
+  autoStopEntriesAtTarget,
+  closeRunningEntries,
+} from '../src/domain/timeTracking/timer';
+import {
+  getTrackedMinutes,
+  totalTrackedMinutes,
+} from '../src/domain/timeTracking';
+import { diffMinutes } from '../src/shared/utils/date';
+import type { Completion, Task, TimeEntry } from '../src/shared/types';
+import { TimeEntrySchema } from '../src/shared/schemas';
+
+function task(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'task-1',
+    title: 'Focus',
+    description: '',
+    category: 'weekday',
+    daysOfWeek: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'],
+    durationMinutes: 30,
+    startYmd: null,
+    autoArchiveAfter: null,
+    repeatCount: null,
+    isActive: true,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('time and schedule domain contracts', () => {
+  test('calculates elapsed whole minutes and clamps negative time', () => {
+    expect(
+      diffMinutes('2026-01-05T10:00:00.000Z', '2026-01-05T10:05:59.000Z'),
+    ).toBe(5);
+    expect(
+      diffMinutes('2026-01-05T10:05:00.000Z', '2026-01-05T10:00:00.000Z'),
+    ).toBe(0);
+  });
+
+  test('returns a safe duration for invalid timestamps', () => {
+    expect(diffMinutes('not-a-timestamp', '2026-01-05T10:00:00.000Z')).toBe(0);
+    expect(diffMinutes('2026-01-05T10:00:00.000Z', 'not-a-timestamp')).toBe(0);
+  });
+
+  test('rejects malformed persisted timestamps while allowing overtime', () => {
+    const entry = {
+      id: 'entry-1',
+      taskId: 'task-1',
+      date: '2026-01-05',
+      startedAt: '2026-01-05T10:00:00.000Z',
+      endedAt: '2026-01-06T12:00:00.000Z',
+      minutes: 1_560,
+    };
+
+    expect(TimeEntrySchema.safeParse(entry).success).toBe(true);
+    expect(
+      TimeEntrySchema.safeParse({ ...entry, startedAt: 'invalid' }).success,
+    ).toBe(false);
+    expect(
+      TimeEntrySchema.safeParse({ ...entry, date: '2026-02-30' }).success,
+    ).toBe(false);
+  });
+
+  test('closes a running entry using timestamps even when it crosses midnight', () => {
+    const entries: TimeEntry[] = [
+      {
+        id: 'entry-1',
+        taskId: 'task-1',
+        date: '2026-01-05',
+        startedAt: '2026-01-05T23:50:00.000Z',
+        endedAt: null,
+        minutes: 0,
+      },
+    ];
+
+    expect(
+      closeRunningEntries(entries, '2026-01-06T00:20:00.000Z'),
+    ).toEqual([
+      {
+        ...entries[0],
+        endedAt: '2026-01-06T00:20:00.000Z',
+        minutes: 30,
+      },
+    ]);
+  });
+
+  test('keeps actual tracked time independent from completion and planned time', () => {
+    const entries: TimeEntry[] = [
+      {
+        id: 'entry-1',
+        taskId: 'task-1',
+        date: '2026-01-05',
+        startedAt: '2026-01-05T10:00:00.000Z',
+        endedAt: '2026-01-05T11:30:00.000Z',
+        minutes: 90,
+      },
+    ];
+
+    expect(getTrackedMinutes(entries[0], '2026-01-05T12:00:00.000Z')).toBe(90);
+    expect(
+      totalTrackedMinutes(
+        entries,
+        'task-1',
+        '2026-01-05',
+        '2026-01-05T12:00:00.000Z',
+      ),
+    ).toBe(90);
+  });
+
+  test('auto-stops a target reached before the current date boundary is rendered', () => {
+    const result = autoStopEntriesAtTarget(
+      [
+        {
+          id: 'entry-1',
+          taskId: 'task-1',
+          date: '2026-01-05',
+          startedAt: '2026-01-05T23:50:00.000Z',
+          endedAt: null,
+          minutes: 0,
+        },
+      ],
+      [task({ durationMinutes: 30 })],
+      [],
+      '2026-01-06T00:20:00.000Z',
+    );
+
+    expect(result.finishedTasks).toEqual([
+      {
+        taskId: 'task-1',
+        title: 'Focus',
+        minutes: 30,
+        autoCompleted: true,
+      },
+    ]);
+    expect(result.completions).toEqual([
+      { taskId: 'task-1', date: '2026-01-05' },
+    ]);
+  });
+
+  test('keeps a task from appearing before its effective start date', () => {
+    expect(
+      pickWeeklySlots(task({ startYmd: '2026-01-08' }), '2026-01-05', []),
+    ).toEqual(['2026-01-08', '2026-01-09']);
+  });
+
+  test('preserves completed slots while applying the weekly backlog limit', () => {
+    const completions: Completion[] = [
+      { taskId: 'task-1', date: '2026-01-05' },
+    ];
+
+    expect(
+      pickWeeklySlots(
+        task({ repeatCount: 2 }),
+        '2026-01-05',
+        completions,
+      ),
+    ).toEqual(['2026-01-05', '2026-01-06']);
+  });
+
+  test('completion toggling does not duplicate or remove unrelated records', () => {
+    const initial: Completion[] = [
+      { taskId: 'task-1', date: '2026-01-05' },
+      { taskId: 'task-2', date: '2026-01-05' },
+    ];
+
+    expect(toggleCompletion(initial, 'task-1', '2026-01-05')).toEqual([
+      { taskId: 'task-2', date: '2026-01-05' },
+    ]);
+    expect(toggleCompletion(initial, 'task-1', '2026-01-06')).toEqual([
+      ...initial,
+      { taskId: 'task-1', date: '2026-01-06' },
+    ]);
+  });
+});
+
+describe('application completion state', () => {
+  test('unchecking completion preserves tracked time for the task and date', () => {
+    const timeEntries: TimeEntry[] = [
+      {
+        id: 'entry-1',
+        taskId: 'task-1',
+        date: '2026-01-05',
+        startedAt: '2026-01-05T10:00:00.000Z',
+        endedAt: '2026-01-05T10:30:00.000Z',
+        minutes: 30,
+      },
+    ];
+
+    useDailyCheckStore.setState({
+      hydrated: true,
+      tasks: [task()],
+      completions: [{ taskId: 'task-1', date: '2026-01-05' }],
+      timeEntries,
+      taskDailyMemos: [],
+      errorMsg: '',
+    });
+
+    useDailyCheckStore.getState().toggleToday({
+      taskId: 'task-1',
+      today: new Date(2026, 0, 5),
+    });
+
+    expect(useDailyCheckStore.getState().completions).toEqual([]);
+    expect(useDailyCheckStore.getState().timeEntries).toEqual(timeEntries);
+  });
+});

--- a/apps/desktop/tests/domain.test.ts
+++ b/apps/desktop/tests/domain.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { useDailyCheckStore } from '../src/app/store/useDailyCheckStore';
+import { useFrilDayStore } from '../src/app/store/useFrilDayStore';
 import { toggleCompletion } from '../src/domain/completion';
 import { pickWeeklySlots } from '../src/domain/schedule/scheduleLimit';
 import {
@@ -206,7 +206,7 @@ describe('application completion state', () => {
       },
     ];
 
-    useDailyCheckStore.setState({
+    useFrilDayStore.setState({
       hydrated: true,
       tasks: [task()],
       completions: [{ taskId: 'task-1', date: '2026-01-05' }],
@@ -215,12 +215,12 @@ describe('application completion state', () => {
       errorMsg: '',
     });
 
-    useDailyCheckStore.getState().toggleToday({
+    useFrilDayStore.getState().toggleToday({
       taskId: 'task-1',
       today: new Date(2026, 0, 5),
     });
 
-    expect(useDailyCheckStore.getState().completions).toEqual([]);
-    expect(useDailyCheckStore.getState().timeEntries).toEqual(timeEntries);
+    expect(useFrilDayStore.getState().completions).toEqual([]);
+    expect(useFrilDayStore.getState().timeEntries).toEqual(timeEntries);
   });
 });

--- a/apps/desktop/tests/domain.test.ts
+++ b/apps/desktop/tests/domain.test.ts
@@ -5,6 +5,7 @@ import { pickWeeklySlots } from '../src/domain/schedule/scheduleLimit';
 import {
   autoStopEntriesAtTarget,
   closeRunningEntries,
+  getRunningTaskId,
 } from '../src/domain/timeTracking/timer';
 import {
   getTrackedMinutes,
@@ -86,6 +87,21 @@ describe('time and schedule domain contracts', () => {
         minutes: 30,
       },
     ]);
+  });
+
+  test('keeps a prior-day running task controllable after midnight', () => {
+    expect(
+      getRunningTaskId([
+        {
+          id: 'entry-1',
+          taskId: 'task-1',
+          date: '2026-01-05',
+          startedAt: '2026-01-05T23:50:00.000Z',
+          endedAt: null,
+          minutes: 0,
+        },
+      ]),
+    ).toBe('task-1');
   });
 
   test('keeps actual tracked time independent from completion and planned time', () => {

--- a/apps/desktop/tests/persistence.test.ts
+++ b/apps/desktop/tests/persistence.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+type FakeStorage = {
+  getItem(key: string): string | null;
+  removeItem(key: string): void;
+  setItem(key: string, value: string): void;
+};
+
+const storageValues = new Map<string, string>();
+const executedSql: string[] = [];
+let migrationMarker = '0';
+let failWrites = false;
+let openTransactions = 0;
+let maxOpenTransactions = 0;
+
+const fakeStorage: FakeStorage = {
+  getItem: (key) => storageValues.get(key) ?? null,
+  removeItem: (key) => storageValues.delete(key),
+  setItem: (key, value) => storageValues.set(key, value),
+};
+
+const fakeAppDb = {
+  init: async () => undefined,
+  execute: async (sql: string) => {
+    executedSql.push(sql.trim());
+    if (sql.trim() === 'BEGIN TRANSACTION') {
+      openTransactions += 1;
+      maxOpenTransactions = Math.max(maxOpenTransactions, openTransactions);
+    }
+    if (failWrites && sql.includes('INSERT INTO tasks')) {
+      throw new Error('simulated write failure');
+    }
+    if (sql.includes('INSERT INTO app_meta')) migrationMarker = '1';
+    if (sql.trim() === 'COMMIT' || sql.trim() === 'ROLLBACK') {
+      openTransactions -= 1;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  },
+  select: async <T>(sql: string): Promise<T[]> => {
+    if (sql.includes('SELECT value FROM app_meta')) {
+      return migrationMarker === '1'
+        ? ([{ value: '1' }] as T[])
+        : ([] as T[]);
+    }
+    if (sql.includes('COUNT(*)')) return [{ count: 0 }] as T[];
+    return [] as T[];
+  },
+};
+
+mock.module('../src/infrastructure/tauri/db.ts', () => ({
+  appDb: fakeAppDb,
+}));
+
+Object.assign(globalThis, {
+  window: {},
+  __TAURI_INTERNALS__: {},
+  localStorage: fakeStorage,
+});
+
+const { loadAppData, replaceAllAppData } = await import(
+  '../src/infrastructure/storage/index.ts'
+);
+
+const validLegacyTask = {
+  id: 'task-legacy',
+  title: 'Migrated task',
+  description: '',
+  category: 'weekday',
+  daysOfWeek: ['Mon'],
+  durationMinutes: 30,
+  startYmd: null,
+  autoArchiveAfter: null,
+  repeatCount: null,
+  isActive: true,
+  createdAt: '2026-01-01T00:00:00.000Z',
+};
+
+describe('SQLite persistence safety', () => {
+  beforeEach(() => {
+    storageValues.clear();
+    executedSql.length = 0;
+    migrationMarker = '0';
+    failWrites = false;
+    openTransactions = 0;
+    maxOpenTransactions = 0;
+  });
+
+  test('migrates valid legacy data before removing legacy keys', async () => {
+    storageValues.set(
+      'dailycheck.tasks.v2',
+      JSON.stringify([validLegacyTask]),
+    );
+
+    const data = await loadAppData();
+
+    expect(data.tasks).toEqual([]);
+    expect(storageValues.has('dailycheck.tasks.v2')).toBe(false);
+    expect(executedSql).toContain('BEGIN TRANSACTION');
+    expect(executedSql).toContain('COMMIT');
+
+    const callsAfterFirstLoad = executedSql.length;
+    await loadAppData();
+    expect(executedSql.length).toBe(callsAfterFirstLoad);
+  });
+
+  test('leaves corrupted legacy input untouched for recovery', async () => {
+    storageValues.set('dailycheck.tasks.v2', '{not valid json');
+
+    await loadAppData();
+
+    expect(storageValues.get('dailycheck.tasks.v2')).toBe('{not valid json');
+    expect(executedSql).not.toContain('DELETE FROM tasks');
+  });
+
+  test('wraps a complete snapshot in one transaction', async () => {
+    await replaceAllAppData({
+      tasks: [],
+      completions: [],
+      timeEntries: [],
+      taskDailyMemos: [],
+    });
+
+    expect(executedSql).toEqual([
+      'INSERT INTO app_meta (key, value)\n      VALUES (?, ?)\n      ON CONFLICT(key) DO UPDATE SET value = excluded.value',
+      'BEGIN TRANSACTION',
+      'DELETE FROM tasks',
+      'DELETE FROM completions',
+      'DELETE FROM time_entries',
+      'DELETE FROM task_daily_memos',
+      'COMMIT',
+    ]);
+  });
+
+  test('rolls back when a snapshot write fails', async () => {
+    failWrites = true;
+
+    await expect(
+      replaceAllAppData({
+        tasks: [validLegacyTask],
+        completions: [],
+        timeEntries: [],
+        taskDailyMemos: [],
+      }),
+    ).rejects.toThrow('simulated write failure');
+
+    expect(executedSql).toContain('BEGIN TRANSACTION');
+    expect(executedSql).toContain('ROLLBACK');
+    expect(executedSql).not.toContain('COMMIT');
+  });
+
+  test('serializes concurrent snapshot saves', async () => {
+    await Promise.all([
+      replaceAllAppData({
+        tasks: [],
+        completions: [],
+        timeEntries: [],
+        taskDailyMemos: [],
+      }),
+      replaceAllAppData({
+        tasks: [],
+        completions: [],
+        timeEntries: [],
+        taskDailyMemos: [],
+      }),
+    ]);
+
+    expect(maxOpenTransactions).toBe(1);
+  });
+});

--- a/apps/desktop/tests/persistence.test.ts
+++ b/apps/desktop/tests/persistence.test.ts
@@ -8,10 +8,13 @@ type FakeStorage = {
 
 const storageValues = new Map<string, string>();
 const executedSql: string[] = [];
+const transactions: string[][] = [];
 let migrationMarker = '0';
 let failWrites = false;
 let openTransactions = 0;
 let maxOpenTransactions = 0;
+let committedTransactions = 0;
+let rolledBackTransactions = 0;
 
 const fakeStorage: FakeStorage = {
   getItem: (key) => storageValues.get(key) ?? null,
@@ -23,18 +26,32 @@ const fakeAppDb = {
   init: async () => undefined,
   execute: async (sql: string) => {
     executedSql.push(sql.trim());
-    if (sql.trim() === 'BEGIN TRANSACTION') {
-      openTransactions += 1;
-      maxOpenTransactions = Math.max(maxOpenTransactions, openTransactions);
-    }
-    if (failWrites && sql.includes('INSERT INTO tasks')) {
-      throw new Error('simulated write failure');
-    }
     if (sql.includes('INSERT INTO app_meta')) migrationMarker = '1';
-    if (sql.trim() === 'COMMIT' || sql.trim() === 'ROLLBACK') {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  },
+  executeTransaction: async (
+    statements: Array<{ sql: string; bind: unknown[] }>,
+  ) => {
+    const sqlStatements = statements.map(({ sql }) => sql.trim());
+    transactions.push(sqlStatements);
+    openTransactions += 1;
+    maxOpenTransactions = Math.max(maxOpenTransactions, openTransactions);
+
+    try {
+      for (const sql of sqlStatements) {
+        executedSql.push(sql);
+        if (failWrites && sql.includes('INSERT INTO tasks')) {
+          throw new Error('simulated write failure');
+        }
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      committedTransactions += 1;
+    } catch (error) {
+      rolledBackTransactions += 1;
+      throw error;
+    } finally {
       openTransactions -= 1;
     }
-    await new Promise((resolve) => setTimeout(resolve, 0));
   },
   select: async <T>(sql: string): Promise<T[]> => {
     if (sql.includes('SELECT value FROM app_meta')) {
@@ -79,10 +96,13 @@ describe('SQLite persistence safety', () => {
   beforeEach(() => {
     storageValues.clear();
     executedSql.length = 0;
+    transactions.length = 0;
     migrationMarker = '0';
     failWrites = false;
     openTransactions = 0;
     maxOpenTransactions = 0;
+    committedTransactions = 0;
+    rolledBackTransactions = 0;
   });
 
   test('migrates valid legacy data before removing legacy keys', async () => {
@@ -95,8 +115,11 @@ describe('SQLite persistence safety', () => {
 
     expect(data.tasks).toEqual([]);
     expect(storageValues.has('dailycheck.tasks.v2')).toBe(false);
-    expect(executedSql).toContain('BEGIN TRANSACTION');
-    expect(executedSql).toContain('COMMIT');
+    expect(transactions).toHaveLength(1);
+    expect(transactions[0]).toContain('DELETE FROM tasks');
+    expect(transactions[0].some((sql) => sql.includes('INSERT INTO tasks'))).toBe(
+      true,
+    );
 
     const callsAfterFirstLoad = executedSql.length;
     await loadAppData();
@@ -120,15 +143,15 @@ describe('SQLite persistence safety', () => {
       taskDailyMemos: [],
     });
 
-    expect(executedSql).toEqual([
-      'INSERT INTO app_meta (key, value)\n      VALUES (?, ?)\n      ON CONFLICT(key) DO UPDATE SET value = excluded.value',
-      'BEGIN TRANSACTION',
-      'DELETE FROM tasks',
-      'DELETE FROM completions',
-      'DELETE FROM time_entries',
-      'DELETE FROM task_daily_memos',
-      'COMMIT',
+    expect(transactions).toEqual([
+      [
+        'DELETE FROM tasks',
+        'DELETE FROM completions',
+        'DELETE FROM time_entries',
+        'DELETE FROM task_daily_memos',
+      ],
     ]);
+    expect(committedTransactions).toBe(1);
   });
 
   test('rolls back when a snapshot write fails', async () => {
@@ -143,9 +166,9 @@ describe('SQLite persistence safety', () => {
       }),
     ).rejects.toThrow('simulated write failure');
 
-    expect(executedSql).toContain('BEGIN TRANSACTION');
-    expect(executedSql).toContain('ROLLBACK');
-    expect(executedSql).not.toContain('COMMIT');
+    expect(transactions).toHaveLength(1);
+    expect(rolledBackTransactions).toBe(1);
+    expect(committedTransactions).toBe(0);
   });
 
   test('serializes concurrent snapshot saves', async () => {

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    println!("Hello, world!");
+    // The server adapter is intentionally separate from the desktop runtime.
 }

--- a/crates/frilday-core/src/lib.rs
+++ b/crates/frilday-core/src/lib.rs
@@ -1,14 +1,1 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+//! Shared FrilDay domain rules live here as they are migrated out of adapters.


### PR DESCRIPTION
## Summary

- audit and harden existing FrilDay desktop behavior
- preserve tracked time independently from completion
- make timer calculations timestamp-based and cross-midnight safe
- serialize and transaction-wrap SQLite snapshot writes
- preserve corrupted legacy data during migration
- strengthen persisted date/timestamp validation
- align docs, branding, and CI with the Tauri adapter architecture
- remove duplicate helpers and bootstrap demo code

## Tests

- npm run test
- npm run lint
- npm run build
- cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml -- --check
- cargo fmt --manifest-path apps/server/Cargo.toml -- --check
- cargo fmt --manifest-path crates/frilday-core/Cargo.toml -- --check
- cargo check and cargo test for apps/server and crates/frilday-core
- cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml

## Follow-up

- migrate durable timer/session and remaining domain rules into frilday-core
- clarify schedule/backlog and historical statistics semantics
- add real-device SQLite integration coverage