### PR TITLE
feat: define stable Routine, Plan, Session, and Completion model

### DIFF
--- a/crates/frilday-core/src/lib.rs
+++ b/crates/frilday-core/src/lib.rs
@@ -8,7 +8,7 @@
 mod model;
 
 pub use model::{
-    Completion, CompletionTarget, Date, DomainError, LocalDate, Plan, PlanId, PlanState,
+    Completion, CompletionKey, Date, DomainError, LocalDate, Plan, PlanId, PlanState,
     PlannedDuration, Routine, RoutineId, RoutineState, ScheduleRule, Session, SessionId, Timestamp,
-    TrackedDuration, Weekday, ensure_single_running_session, toggle_completion,
+    TrackedDuration, Weekday, ensure_single_running_session, start_session, toggle_completion,
 };

--- a/crates/frilday-core/src/lib.rs
+++ b/crates/frilday-core/src/lib.rs
@@ -1,1 +1,14 @@
 //! Shared FrilDay domain rules live here as they are migrated out of adapters.
+//!
+//! This crate intentionally has no framework, transport, or persistence
+//! dependencies. The public model is the vocabulary shared by future desktop
+//! and server adapters; adapters are responsible for translating their own
+//! storage and timestamp formats into these types.
+
+mod model;
+
+pub use model::{
+    Completion, CompletionTarget, Date, DomainError, LocalDate, Plan, PlanId, PlanState,
+    PlannedDuration, Routine, RoutineId, RoutineState, ScheduleRule, Session, SessionId, Timestamp,
+    TrackedDuration, Weekday, ensure_single_running_session, toggle_completion,
+};

--- a/crates/frilday-core/src/model.rs
+++ b/crates/frilday-core/src/model.rs
@@ -14,7 +14,6 @@ pub enum DomainError {
     SessionEndsBeforeItStarts,
     SessionAlreadyEnded,
     MultipleRunningSessions,
-    InvalidCompletionTarget,
 }
 
 impl fmt::Display for DomainError {
@@ -39,9 +38,6 @@ impl fmt::Display for DomainError {
             }
             Self::SessionAlreadyEnded => f.write_str("session has already ended"),
             Self::MultipleRunningSessions => f.write_str("only one session may be running"),
-            Self::InvalidCompletionTarget => {
-                f.write_str("completion target must identify a routine or plan")
-            }
         }
     }
 }
@@ -133,6 +129,37 @@ impl LocalDate {
 
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+
+    /// Return the weekday for this local calendar date without timezone
+    /// conversion. The core owns this calculation so callers cannot pass a
+    /// weekday that disagrees with the date.
+    pub fn weekday(&self) -> Weekday {
+        let year = self.0[0..4].parse::<u32>().expect("LocalDate is validated");
+        let month = self.0[5..7]
+            .parse::<usize>()
+            .expect("LocalDate is validated");
+        let day = self.0[8..10]
+            .parse::<u32>()
+            .expect("LocalDate is validated");
+        let offsets = [0_u32, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4];
+        let adjusted_year = year - u32::from(month < 3);
+        let sunday_first = (adjusted_year + adjusted_year / 4 - adjusted_year / 100
+            + adjusted_year / 400
+            + offsets[month - 1]
+            + day)
+            % 7;
+
+        match sunday_first {
+            0 => Weekday::Sunday,
+            1 => Weekday::Monday,
+            2 => Weekday::Tuesday,
+            3 => Weekday::Wednesday,
+            4 => Weekday::Thursday,
+            5 => Weekday::Friday,
+            6 => Weekday::Saturday,
+            _ => unreachable!("weekday is modulo seven"),
+        }
     }
 }
 
@@ -373,13 +400,13 @@ impl Routine {
         self.state == RoutineState::Active
     }
 
-    pub fn is_eligible_on(&self, date: &LocalDate, weekday: Weekday) -> bool {
+    pub fn is_eligible_on(&self, date: &LocalDate) -> bool {
         self.is_active()
             && self
                 .starts_on
                 .as_ref()
                 .is_none_or(|starts_on| date >= starts_on)
-            && self.schedule.includes(weekday)
+            && self.schedule.includes(date.weekday())
     }
 
     pub fn id(&self) -> &RoutineId {
@@ -594,37 +621,89 @@ pub fn ensure_single_running_session(sessions: &[Session]) -> Result<(), DomainE
     Ok(())
 }
 
+/// Start a running session while enforcing the desktop's single-running-
+/// session invariant atomically for the supplied collection.
+pub fn start_session(sessions: &mut Vec<Session>, session: Session) -> Result<(), DomainError> {
+    ensure_single_running_session(sessions)?;
+    if !session.is_running() || sessions.iter().any(Session::is_running) {
+        return Err(if session.is_running() {
+            DomainError::MultipleRunningSessions
+        } else {
+            DomainError::SessionAlreadyEnded
+        });
+    }
+    sessions.push(session);
+    Ok(())
+}
+
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub enum CompletionTarget {
-    Routine(RoutineId),
-    Plan(PlanId),
+pub enum CompletionKey {
+    RoutineDate {
+        routine_id: RoutineId,
+        date: LocalDate,
+    },
+    PlanDate {
+        plan_id: PlanId,
+        date: LocalDate,
+    },
 }
 
 /// A binary signal for a routine/date or plan/date. It intentionally has no
 /// session reference: completion and time investment are independent facts.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Completion {
-    target: CompletionTarget,
+    routine_id: Option<RoutineId>,
+    plan_id: Option<PlanId>,
     date: LocalDate,
 }
 
 impl Completion {
     pub fn for_routine(routine_id: RoutineId, date: LocalDate) -> Self {
         Self {
-            target: CompletionTarget::Routine(routine_id),
+            routine_id: Some(routine_id),
+            plan_id: None,
+            date,
+        }
+    }
+
+    pub fn for_routine_plan(routine_id: RoutineId, plan_id: PlanId, date: LocalDate) -> Self {
+        Self {
+            routine_id: Some(routine_id),
+            plan_id: Some(plan_id),
             date,
         }
     }
 
     pub fn for_plan(plan_id: PlanId, date: LocalDate) -> Self {
         Self {
-            target: CompletionTarget::Plan(plan_id),
+            routine_id: None,
+            plan_id: Some(plan_id),
             date,
         }
     }
 
-    pub fn target(&self) -> &CompletionTarget {
-        &self.target
+    /// Return the canonical toggle key. A historical completion may retain
+    /// both IDs, but a routine/date key remains canonical when present.
+    pub fn key(&self) -> CompletionKey {
+        match (&self.routine_id, &self.plan_id) {
+            (Some(routine_id), _) => CompletionKey::RoutineDate {
+                routine_id: routine_id.clone(),
+                date: self.date.clone(),
+            },
+            (None, Some(plan_id)) => CompletionKey::PlanDate {
+                plan_id: plan_id.clone(),
+                date: self.date.clone(),
+            },
+            (None, None) => unreachable!("Completion constructors always set a target"),
+        }
+    }
+
+    pub fn routine_id(&self) -> Option<&RoutineId> {
+        self.routine_id.as_ref()
+    }
+
+    pub fn plan_id(&self) -> Option<&PlanId> {
+        self.plan_id.as_ref()
     }
 
     pub fn date(&self) -> &LocalDate {
@@ -634,14 +713,18 @@ impl Completion {
 
 /// Toggle one completion without touching sessions or other completion keys.
 pub fn toggle_completion(completions: &[Completion], completion: Completion) -> Vec<Completion> {
-    let exists = completions.iter().any(|current| current == &completion);
+    let key = completion.key();
+    let exists = completions.iter().any(|current| current.key() == key);
     if exists {
         completions
             .iter()
-            .filter(|current| *current != &completion)
+            .filter(|current| current.key() != key)
             .cloned()
             .collect()
     } else {
+        if completions.iter().any(|current| current.key() == key) {
+            return completions.to_vec();
+        }
         let mut next = completions.to_vec();
         next.push(completion);
         next
@@ -715,7 +798,7 @@ mod tests {
         routine.archive();
         assert_eq!(routine.state(), RoutineState::Archived);
         assert_eq!(routine.id().as_str(), "routine-1");
-        assert!(!routine.is_eligible_on(&date("2026-01-12"), Weekday::Monday));
+        assert!(!routine.is_eligible_on(&date("2026-01-12")));
     }
 
     #[test]
@@ -851,12 +934,66 @@ mod tests {
     }
 
     #[test]
-    fn completion_toggles_independently_of_session_data() {
-        let completion = Completion::for_routine(id("routine-1"), date("2026-01-12"));
+    fn starting_a_second_running_session_is_rejected_before_insertion() {
+        let first = Session::new(
+            session_id("session-1"),
+            Some(id("routine-1")),
+            None,
+            Timestamp::from_unix_seconds(10),
+            None,
+        )
+        .unwrap();
+        let second = Session::new(
+            session_id("session-2"),
+            Some(id("routine-2")),
+            None,
+            Timestamp::from_unix_seconds(20),
+            None,
+        )
+        .unwrap();
+        let mut sessions = vec![first];
+        assert_eq!(
+            start_session(&mut sessions, second),
+            Err(DomainError::MultipleRunningSessions)
+        );
+        assert_eq!(sessions.len(), 1);
+    }
+
+    #[test]
+    fn completion_keeps_historical_plan_association_but_toggles_by_routine_date() {
+        let completion =
+            Completion::for_routine_plan(id("routine-1"), plan_id("plan-1"), date("2026-01-12"));
         let other = Completion::for_plan(plan_id("plan-2"), date("2026-01-12"));
+        assert_eq!(completion.routine_id().unwrap().as_str(), "routine-1");
+        assert_eq!(completion.plan_id().unwrap().as_str(), "plan-1");
+
         let one = toggle_completion(&[], completion.clone());
         let two = toggle_completion(&one, other.clone());
         assert_eq!(two, vec![completion.clone(), other.clone()]);
-        assert_eq!(toggle_completion(&two, completion), vec![other]);
+        assert_eq!(
+            toggle_completion(
+                &two,
+                Completion::for_routine(id("routine-1"), date("2026-01-12"))
+            ),
+            vec![other]
+        );
+    }
+
+    #[test]
+    fn eligibility_derives_weekday_from_local_date() {
+        let routine = Routine::new(
+            id("routine-1"),
+            "Weekend",
+            "",
+            minutes(30),
+            ScheduleRule::weekends(),
+            Timestamp::from_unix_seconds(1),
+            date("2026-01-01"),
+            None,
+        )
+        .unwrap();
+
+        assert!(routine.is_eligible_on(&date("2026-01-11"))); // Sunday
+        assert!(!routine.is_eligible_on(&date("2026-01-12"))); // Monday
     }
 }

--- a/crates/frilday-core/src/model.rs
+++ b/crates/frilday-core/src/model.rs
@@ -1,0 +1,862 @@
+use std::{fmt, str::FromStr};
+
+/// Errors raised when an entity would violate a domain invariant.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DomainError {
+    EmptyId(&'static str),
+    EmptyTitle,
+    InvalidDate(String),
+    InvalidDuration,
+    EmptyCustomSchedule,
+    DuplicateCustomScheduleDay,
+    StartDateBeforeCreation,
+    MissingSessionAssociation,
+    SessionEndsBeforeItStarts,
+    SessionAlreadyEnded,
+    MultipleRunningSessions,
+    InvalidCompletionTarget,
+}
+
+impl fmt::Display for DomainError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyId(entity) => write!(f, "{entity} id cannot be empty"),
+            Self::EmptyTitle => f.write_str("routine title cannot be empty"),
+            Self::InvalidDate(value) => write!(f, "invalid local date: {value}"),
+            Self::InvalidDuration => f.write_str("planned duration must be positive"),
+            Self::EmptyCustomSchedule => f.write_str("custom schedule needs at least one day"),
+            Self::DuplicateCustomScheduleDay => {
+                f.write_str("custom schedule cannot contain duplicate days")
+            }
+            Self::StartDateBeforeCreation => {
+                f.write_str("routine start date cannot be before its creation date")
+            }
+            Self::MissingSessionAssociation => {
+                f.write_str("session must be associated with a routine or plan")
+            }
+            Self::SessionEndsBeforeItStarts => {
+                f.write_str("session end timestamp cannot be before its start timestamp")
+            }
+            Self::SessionAlreadyEnded => f.write_str("session has already ended"),
+            Self::MultipleRunningSessions => f.write_str("only one session may be running"),
+            Self::InvalidCompletionTarget => {
+                f.write_str("completion target must identify a routine or plan")
+            }
+        }
+    }
+}
+
+impl std::error::Error for DomainError {}
+
+macro_rules! entity_id {
+    ($name:ident, $label:literal) => {
+        #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn new(value: impl Into<String>) -> Result<Self, DomainError> {
+                let value = value.into();
+                if value.trim().is_empty() {
+                    return Err(DomainError::EmptyId($label));
+                }
+                Ok(Self(value))
+            }
+
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+    };
+}
+
+entity_id!(RoutineId, "routine");
+entity_id!(PlanId, "plan");
+entity_id!(SessionId, "session");
+
+/// A calendar date in the user's local desktop timezone.
+///
+/// Dates are intentionally separate from instants. They are persisted and
+/// compared in canonical `YYYY-MM-DD` form and must not be calculated by
+/// converting through UTC.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct LocalDate(String);
+
+/// Short alias used by the domain documentation and adapters.
+pub type Date = LocalDate;
+
+impl LocalDate {
+    pub fn new(value: impl Into<String>) -> Result<Self, DomainError> {
+        let value = value.into();
+        let bytes = value.as_bytes();
+        let valid_shape = bytes.len() == 10
+            && bytes[4] == b'-'
+            && bytes[7] == b'-'
+            && bytes
+                .iter()
+                .enumerate()
+                .all(|(index, byte)| matches!(index, 4 | 7) || byte.is_ascii_digit());
+
+        if !valid_shape {
+            return Err(DomainError::InvalidDate(value));
+        }
+
+        let year = value[0..4]
+            .parse::<u32>()
+            .map_err(|_| DomainError::InvalidDate(value.clone()))?;
+        let month = value[5..7]
+            .parse::<u32>()
+            .map_err(|_| DomainError::InvalidDate(value.clone()))?;
+        let day = value[8..10]
+            .parse::<u32>()
+            .map_err(|_| DomainError::InvalidDate(value.clone()))?;
+
+        let days_in_month = match month {
+            1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+            4 | 6 | 9 | 11 => 30,
+            2 if is_leap_year(year) => 29,
+            2 => 28,
+            _ => 0,
+        };
+
+        if year == 0 || days_in_month == 0 || day == 0 || day > days_in_month {
+            return Err(DomainError::InvalidDate(value));
+        }
+
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for LocalDate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl FromStr for LocalDate {
+    type Err = DomainError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::new(value)
+    }
+}
+
+fn is_leap_year(year: u32) -> bool {
+    year.is_multiple_of(4) && (!year.is_multiple_of(100) || year.is_multiple_of(400))
+}
+
+/// An instant represented as signed Unix seconds.
+///
+/// ISO-8601 parsing and formatting belong in an adapter. Keeping the core
+/// representation numeric makes duration calculations deterministic and free
+/// of timezone/database dependencies.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Timestamp(i64);
+
+impl Timestamp {
+    pub const fn from_unix_seconds(seconds: i64) -> Self {
+        Self(seconds)
+    }
+
+    pub const fn unix_seconds(self) -> i64 {
+        self.0
+    }
+}
+
+/// A routine's planned duration, expressed in whole minutes.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct PlannedDuration(u32);
+
+impl PlannedDuration {
+    pub const fn new(minutes: u32) -> Result<Self, DomainError> {
+        if minutes == 0 {
+            Err(DomainError::InvalidDuration)
+        } else {
+            Ok(Self(minutes))
+        }
+    }
+
+    pub const fn minutes(self) -> u32 {
+        self.0
+    }
+}
+
+/// Actual tracked time. It may be zero for a session shorter than one minute.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct TrackedDuration {
+    seconds: u64,
+}
+
+impl TrackedDuration {
+    pub const fn from_seconds(seconds: u64) -> Self {
+        Self { seconds }
+    }
+
+    pub const fn seconds(self) -> u64 {
+        self.seconds
+    }
+
+    pub const fn whole_minutes(self) -> u64 {
+        self.seconds / 60
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum Weekday {
+    Monday,
+    Tuesday,
+    Wednesday,
+    Thursday,
+    Friday,
+    Saturday,
+    Sunday,
+}
+
+/// A validated recurring schedule. Custom days are private so callers cannot
+/// construct an empty or duplicate schedule without going through validation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ScheduleRule {
+    days: Vec<Weekday>,
+}
+
+impl ScheduleRule {
+    pub fn daily() -> Self {
+        Self {
+            days: vec![
+                Weekday::Monday,
+                Weekday::Tuesday,
+                Weekday::Wednesday,
+                Weekday::Thursday,
+                Weekday::Friday,
+                Weekday::Saturday,
+                Weekday::Sunday,
+            ],
+        }
+    }
+
+    pub fn weekdays() -> Self {
+        Self {
+            days: vec![
+                Weekday::Monday,
+                Weekday::Tuesday,
+                Weekday::Wednesday,
+                Weekday::Thursday,
+                Weekday::Friday,
+            ],
+        }
+    }
+
+    pub fn weekends() -> Self {
+        Self {
+            days: vec![Weekday::Saturday, Weekday::Sunday],
+        }
+    }
+
+    pub fn custom(days: impl Into<Vec<Weekday>>) -> Result<Self, DomainError> {
+        let days = days.into();
+        if days.is_empty() {
+            return Err(DomainError::EmptyCustomSchedule);
+        }
+
+        for (index, day) in days.iter().enumerate() {
+            if days[..index].contains(day) {
+                return Err(DomainError::DuplicateCustomScheduleDay);
+            }
+        }
+
+        Ok(Self { days })
+    }
+
+    pub fn includes(&self, weekday: Weekday) -> bool {
+        self.days.contains(&weekday)
+    }
+
+    pub fn days(&self) -> &[Weekday] {
+        &self.days
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RoutineState {
+    Active,
+    Archived,
+}
+
+/// A reusable intention/rule. A routine is not a record of work on a date.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Routine {
+    id: RoutineId,
+    title: String,
+    description: String,
+    default_planned_duration: PlannedDuration,
+    schedule: ScheduleRule,
+    created_at: Timestamp,
+    created_on: LocalDate,
+    starts_on: Option<LocalDate>,
+    state: RoutineState,
+    archive_after_completions: Option<u32>,
+    max_planned_occurrences: Option<u32>,
+}
+
+impl Routine {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: RoutineId,
+        title: impl Into<String>,
+        description: impl Into<String>,
+        default_planned_duration: PlannedDuration,
+        schedule: ScheduleRule,
+        created_at: Timestamp,
+        created_on: LocalDate,
+        starts_on: Option<LocalDate>,
+    ) -> Result<Self, DomainError> {
+        let title = title.into().trim().to_owned();
+        if title.is_empty() {
+            return Err(DomainError::EmptyTitle);
+        }
+        if starts_on.as_ref().is_some_and(|date| date < &created_on) {
+            return Err(DomainError::StartDateBeforeCreation);
+        }
+
+        Ok(Self {
+            id,
+            title,
+            description: description.into().trim().to_owned(),
+            default_planned_duration,
+            schedule,
+            created_at,
+            created_on,
+            starts_on,
+            state: RoutineState::Active,
+            archive_after_completions: None,
+            max_planned_occurrences: None,
+        })
+    }
+
+    pub fn with_archive_after_completions(
+        mut self,
+        count: Option<u32>,
+    ) -> Result<Self, DomainError> {
+        if count == Some(0) {
+            return Err(DomainError::InvalidDuration);
+        }
+        self.archive_after_completions = count;
+        Ok(self)
+    }
+
+    pub fn with_max_planned_occurrences(mut self, count: Option<u32>) -> Result<Self, DomainError> {
+        if count == Some(0) {
+            return Err(DomainError::InvalidDuration);
+        }
+        self.max_planned_occurrences = count;
+        Ok(self)
+    }
+
+    pub fn archive(&mut self) {
+        self.state = RoutineState::Archived;
+    }
+
+    pub fn restore(&mut self) {
+        self.state = RoutineState::Active;
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.state == RoutineState::Active
+    }
+
+    pub fn is_eligible_on(&self, date: &LocalDate, weekday: Weekday) -> bool {
+        self.is_active()
+            && self
+                .starts_on
+                .as_ref()
+                .is_none_or(|starts_on| date >= starts_on)
+            && self.schedule.includes(weekday)
+    }
+
+    pub fn id(&self) -> &RoutineId {
+        &self.id
+    }
+
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    pub fn default_planned_duration(&self) -> PlannedDuration {
+        self.default_planned_duration
+    }
+
+    pub fn schedule(&self) -> &ScheduleRule {
+        &self.schedule
+    }
+
+    pub fn created_at(&self) -> Timestamp {
+        self.created_at
+    }
+
+    pub fn created_on(&self) -> &LocalDate {
+        &self.created_on
+    }
+
+    pub fn starts_on(&self) -> Option<&LocalDate> {
+        self.starts_on.as_ref()
+    }
+
+    pub fn state(&self) -> RoutineState {
+        self.state
+    }
+
+    pub fn archive_after_completions(&self) -> Option<u32> {
+        self.archive_after_completions
+    }
+
+    pub fn max_planned_occurrences(&self) -> Option<u32> {
+        self.max_planned_occurrences
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PlanState {
+    Planned,
+    Skipped,
+    Moved { to: LocalDate },
+}
+
+/// A date-specific intention. Its duration is a snapshot for that date.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Plan {
+    id: PlanId,
+    routine_id: Option<RoutineId>,
+    date: LocalDate,
+    planned_duration: PlannedDuration,
+    duration_override: Option<PlannedDuration>,
+    state: PlanState,
+}
+
+impl Plan {
+    pub fn new(
+        id: PlanId,
+        routine_id: Option<RoutineId>,
+        date: LocalDate,
+        routine_default_duration: PlannedDuration,
+        duration_override: Option<PlannedDuration>,
+    ) -> Self {
+        let planned_duration = duration_override.unwrap_or(routine_default_duration);
+        Self {
+            id,
+            routine_id,
+            date,
+            planned_duration,
+            duration_override,
+            state: PlanState::Planned,
+        }
+    }
+
+    pub fn skip(&mut self) {
+        self.state = PlanState::Skipped;
+    }
+
+    pub fn move_to(&mut self, date: LocalDate) {
+        self.state = PlanState::Moved { to: date };
+    }
+
+    pub fn id(&self) -> &PlanId {
+        &self.id
+    }
+
+    pub fn routine_id(&self) -> Option<&RoutineId> {
+        self.routine_id.as_ref()
+    }
+
+    pub fn date(&self) -> &LocalDate {
+        &self.date
+    }
+
+    pub fn planned_duration(&self) -> PlannedDuration {
+        self.planned_duration
+    }
+
+    pub fn duration_override(&self) -> Option<PlannedDuration> {
+        self.duration_override
+    }
+
+    pub fn state(&self) -> &PlanState {
+        &self.state
+    }
+}
+
+/// A real interval of tracked work. Duration is always derived from timestamps;
+/// no mutable cached minute field is part of the entity.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Session {
+    id: SessionId,
+    routine_id: Option<RoutineId>,
+    plan_id: Option<PlanId>,
+    started_at: Timestamp,
+    ended_at: Option<Timestamp>,
+}
+
+impl Session {
+    pub fn new(
+        id: SessionId,
+        routine_id: Option<RoutineId>,
+        plan_id: Option<PlanId>,
+        started_at: Timestamp,
+        ended_at: Option<Timestamp>,
+    ) -> Result<Self, DomainError> {
+        if routine_id.is_none() && plan_id.is_none() {
+            return Err(DomainError::MissingSessionAssociation);
+        }
+        if ended_at.is_some_and(|ended_at| ended_at < started_at) {
+            return Err(DomainError::SessionEndsBeforeItStarts);
+        }
+
+        Ok(Self {
+            id,
+            routine_id,
+            plan_id,
+            started_at,
+            ended_at,
+        })
+    }
+
+    pub fn finish(&mut self, ended_at: Timestamp) -> Result<(), DomainError> {
+        if self.ended_at.is_some() {
+            return Err(DomainError::SessionAlreadyEnded);
+        }
+        if ended_at < self.started_at {
+            return Err(DomainError::SessionEndsBeforeItStarts);
+        }
+        self.ended_at = Some(ended_at);
+        Ok(())
+    }
+
+    pub fn actual_duration_at(&self, now: Timestamp) -> Result<TrackedDuration, DomainError> {
+        let end = self.ended_at.unwrap_or(now);
+        let seconds = end
+            .unix_seconds()
+            .checked_sub(self.started_at.unix_seconds())
+            .ok_or(DomainError::SessionEndsBeforeItStarts)?;
+        if seconds < 0 {
+            return Err(DomainError::SessionEndsBeforeItStarts);
+        }
+        Ok(TrackedDuration::from_seconds(seconds as u64))
+    }
+
+    pub fn is_running(&self) -> bool {
+        self.ended_at.is_none()
+    }
+
+    pub fn id(&self) -> &SessionId {
+        &self.id
+    }
+
+    pub fn routine_id(&self) -> Option<&RoutineId> {
+        self.routine_id.as_ref()
+    }
+
+    pub fn plan_id(&self) -> Option<&PlanId> {
+        self.plan_id.as_ref()
+    }
+
+    pub fn started_at(&self) -> Timestamp {
+        self.started_at
+    }
+
+    pub fn ended_at(&self) -> Option<Timestamp> {
+        self.ended_at
+    }
+}
+
+/// Validate the aggregate-level invariant that there is at most one running
+/// session in the local desktop application.
+pub fn ensure_single_running_session(sessions: &[Session]) -> Result<(), DomainError> {
+    if sessions
+        .iter()
+        .filter(|session| session.is_running())
+        .count()
+        > 1
+    {
+        return Err(DomainError::MultipleRunningSessions);
+    }
+    Ok(())
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum CompletionTarget {
+    Routine(RoutineId),
+    Plan(PlanId),
+}
+
+/// A binary signal for a routine/date or plan/date. It intentionally has no
+/// session reference: completion and time investment are independent facts.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Completion {
+    target: CompletionTarget,
+    date: LocalDate,
+}
+
+impl Completion {
+    pub fn for_routine(routine_id: RoutineId, date: LocalDate) -> Self {
+        Self {
+            target: CompletionTarget::Routine(routine_id),
+            date,
+        }
+    }
+
+    pub fn for_plan(plan_id: PlanId, date: LocalDate) -> Self {
+        Self {
+            target: CompletionTarget::Plan(plan_id),
+            date,
+        }
+    }
+
+    pub fn target(&self) -> &CompletionTarget {
+        &self.target
+    }
+
+    pub fn date(&self) -> &LocalDate {
+        &self.date
+    }
+}
+
+/// Toggle one completion without touching sessions or other completion keys.
+pub fn toggle_completion(completions: &[Completion], completion: Completion) -> Vec<Completion> {
+    let exists = completions.iter().any(|current| current == &completion);
+    if exists {
+        completions
+            .iter()
+            .filter(|current| *current != &completion)
+            .cloned()
+            .collect()
+    } else {
+        let mut next = completions.to_vec();
+        next.push(completion);
+        next
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(value: &str) -> RoutineId {
+        RoutineId::new(value).unwrap()
+    }
+
+    fn plan_id(value: &str) -> PlanId {
+        PlanId::new(value).unwrap()
+    }
+
+    fn session_id(value: &str) -> SessionId {
+        SessionId::new(value).unwrap()
+    }
+
+    fn date(value: &str) -> LocalDate {
+        LocalDate::new(value).unwrap()
+    }
+
+    fn minutes(value: u32) -> PlannedDuration {
+        PlannedDuration::new(value).unwrap()
+    }
+
+    #[test]
+    fn validates_stable_ids_and_calendar_dates() {
+        assert_eq!(RoutineId::new("  "), Err(DomainError::EmptyId("routine")));
+        assert!(LocalDate::new("2026-02-29").is_err());
+        assert!(LocalDate::new("2028-02-29").is_ok());
+        assert!(LocalDate::new("2026-02-30").is_err());
+    }
+
+    #[test]
+    fn planned_duration_is_positive_and_actual_duration_can_be_zero() {
+        assert_eq!(PlannedDuration::new(0), Err(DomainError::InvalidDuration));
+        assert_eq!(TrackedDuration::from_seconds(59).whole_minutes(), 0);
+    }
+
+    #[test]
+    fn routine_rejects_a_start_before_creation_and_can_be_archived_without_losing_identity() {
+        let created_on = date("2026-01-10");
+        let result = Routine::new(
+            id("routine-1"),
+            "English study",
+            "",
+            minutes(30),
+            ScheduleRule::daily(),
+            Timestamp::from_unix_seconds(1),
+            created_on.clone(),
+            Some(date("2026-01-09")),
+        );
+        assert_eq!(result, Err(DomainError::StartDateBeforeCreation));
+
+        let mut routine = Routine::new(
+            id("routine-1"),
+            " English study ",
+            " description ",
+            minutes(30),
+            ScheduleRule::weekdays(),
+            Timestamp::from_unix_seconds(1),
+            created_on,
+            None,
+        )
+        .unwrap();
+        routine.archive();
+        assert_eq!(routine.state(), RoutineState::Archived);
+        assert_eq!(routine.id().as_str(), "routine-1");
+        assert!(!routine.is_eligible_on(&date("2026-01-12"), Weekday::Monday));
+    }
+
+    #[test]
+    fn custom_schedule_rejects_empty_and_duplicate_days() {
+        assert_eq!(
+            ScheduleRule::custom(Vec::new()),
+            Err(DomainError::EmptyCustomSchedule)
+        );
+        assert_eq!(
+            ScheduleRule::custom(vec![Weekday::Monday, Weekday::Monday]),
+            Err(DomainError::DuplicateCustomScheduleDay)
+        );
+    }
+
+    #[test]
+    fn plan_keeps_effective_planned_duration_and_override_separate() {
+        let plan = Plan::new(
+            plan_id("plan-1"),
+            Some(id("routine-1")),
+            date("2026-01-12"),
+            minutes(30),
+            Some(minutes(45)),
+        );
+        assert_eq!(plan.planned_duration().minutes(), 45);
+        assert_eq!(plan.duration_override().unwrap().minutes(), 45);
+        assert_eq!(plan.state(), &PlanState::Planned);
+    }
+
+    #[test]
+    fn plan_can_be_skipped_or_moved_without_changing_its_original_date() {
+        let mut plan = Plan::new(
+            plan_id("plan-1"),
+            None,
+            date("2026-01-12"),
+            minutes(30),
+            None,
+        );
+        plan.move_to(date("2026-01-13"));
+        assert_eq!(plan.date().as_str(), "2026-01-12");
+        assert_eq!(
+            plan.state(),
+            &PlanState::Moved {
+                to: date("2026-01-13")
+            }
+        );
+        plan.skip();
+        assert_eq!(plan.state(), &PlanState::Skipped);
+    }
+
+    #[test]
+    fn session_derives_actual_time_from_timestamps_and_supports_running_state() {
+        let session = Session::new(
+            session_id("session-1"),
+            Some(id("routine-1")),
+            None,
+            Timestamp::from_unix_seconds(10 * 60),
+            Some(Timestamp::from_unix_seconds(95 * 60)),
+        )
+        .unwrap();
+        assert_eq!(
+            session
+                .actual_duration_at(Timestamp::from_unix_seconds(120 * 60))
+                .unwrap()
+                .whole_minutes(),
+            85
+        );
+        assert!(!session.is_running());
+
+        let running = Session::new(
+            session_id("session-2"),
+            Some(id("routine-1")),
+            None,
+            Timestamp::from_unix_seconds(10 * 60),
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            running
+                .actual_duration_at(Timestamp::from_unix_seconds(12 * 60))
+                .unwrap()
+                .whole_minutes(),
+            2
+        );
+    }
+
+    #[test]
+    fn session_rejects_missing_association_and_backwards_time() {
+        assert_eq!(
+            Session::new(
+                session_id("session-1"),
+                None,
+                None,
+                Timestamp::from_unix_seconds(10),
+                None,
+            ),
+            Err(DomainError::MissingSessionAssociation)
+        );
+        assert_eq!(
+            Session::new(
+                session_id("session-1"),
+                Some(id("routine-1")),
+                None,
+                Timestamp::from_unix_seconds(20),
+                Some(Timestamp::from_unix_seconds(10)),
+            ),
+            Err(DomainError::SessionEndsBeforeItStarts)
+        );
+    }
+
+    #[test]
+    fn only_one_running_session_is_allowed() {
+        let first = Session::new(
+            session_id("session-1"),
+            Some(id("routine-1")),
+            None,
+            Timestamp::from_unix_seconds(10),
+            None,
+        )
+        .unwrap();
+        let second = Session::new(
+            session_id("session-2"),
+            Some(id("routine-2")),
+            None,
+            Timestamp::from_unix_seconds(20),
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            ensure_single_running_session(&[first.clone(), second]),
+            Err(DomainError::MultipleRunningSessions)
+        );
+        assert!(ensure_single_running_session(&[first]).is_ok());
+    }
+
+    #[test]
+    fn completion_toggles_independently_of_session_data() {
+        let completion = Completion::for_routine(id("routine-1"), date("2026-01-12"));
+        let other = Completion::for_plan(plan_id("plan-2"), date("2026-01-12"));
+        let one = toggle_completion(&[], completion.clone());
+        let two = toggle_completion(&one, other.clone());
+        assert_eq!(two, vec![completion.clone(), other.clone()]);
+        assert_eq!(toggle_completion(&two, completion), vec![other]);
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -48,6 +48,10 @@ The current scaffold is still mid-extraction: active domain and SQLite
 integration remain under `apps/desktop`, while `crates/frilday-core` is not
 yet wired into the desktop crate.
 
+The stable Routine/Plan/Session/Completion vocabulary and the compatibility
+mapping for the current desktop records are defined in
+[DOMAIN_MODEL.md](DOMAIN_MODEL.md).
+
 ### Future server delivery
 
 ```text
@@ -94,6 +98,7 @@ It is not part of the desktop v0.1 runtime and should not own domain rules.
 
 Responsible for reusable rules such as:
 
+- Routine, Plan, Session, and Completion domain semantics
 - task and time-planning logic
 - schedule rules
 - timer and time-entry rules

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -1,0 +1,185 @@
+# FrilDay Domain Model
+
+This document defines the stable vocabulary for the FrilDay v0.1 planning
+loop. It is deliberately separate from React, Tauri, SQLite, and HTTP so
+future delivery adapters cannot redefine the meaning of planned or actual
+time.
+
+## Product boundary
+
+FrilDay is built around:
+
+```text
+Plan → Execute → Track → Review → Adjust
+```
+
+The primary comparison is planned time versus actual tracked time.
+Completion is useful context, but it is not a replacement for time tracking.
+
+The dependency-free Rust types in `crates/frilday-core/src/model.rs` are the
+initial executable form of this vocabulary. The desktop currently still uses
+its legacy TypeScript and SQLite shapes; the later extraction and persistence
+issues must add adapters without changing these meanings.
+
+## Concepts
+
+### Routine
+
+A `Routine` is a reusable intention and schedule rule, such as `English
+study`, `Gym`, or `Rust study`. It contains:
+
+- a stable `RoutineId`;
+- title and description;
+- a default planned duration in whole minutes;
+- a recurring schedule rule;
+- a local start date, when one is set;
+- active or archived state;
+- its creation instant and creation local date;
+- optional completion/archive and finite-planning limits needed by the
+  current desktop behavior.
+
+A Routine is not an execution record and has no date-specific actual duration.
+Archiving prevents new schedule eligibility but never removes historical
+Plans, Sessions, Completions, or notes. Explicit permanent deletion is a
+separate destructive operation and must not be used as archive behavior.
+
+### Plan
+
+A `Plan` is a concrete intention for one local calendar date. It contains:
+
+- a stable `PlanId`;
+- an optional source `RoutineId` (allowing a future ad-hoc plan);
+- the local date;
+- the effective planned duration for that date;
+- an optional date-specific duration override;
+- `Planned`, `Skipped`, or `Moved { to }` state.
+
+The effective planned duration is a snapshot. If a routine's default changes
+later, an existing Plan does not silently change. A date override is recorded
+separately while `planned_duration` remains the value used for planned-versus-
+actual comparisons.
+
+### Session
+
+A `Session` is a real interval of tracked work. It contains:
+
+- a stable `SessionId`;
+- a Routine and/or Plan association;
+- a start instant;
+- an optional end instant, where `None` means running.
+
+Actual duration is derived from the timestamps (whole minutes are available as
+an aggregation view). A mutable cached `minutes` column is not a source of
+truth. An end before the start is invalid. A session may cross local midnight;
+its plan/date association remains the one selected when the session started,
+while its elapsed interval still uses the complete timestamps.
+
+Desktop v0.1 permits at most one running Session across the application. A
+start operation must validate the collection-level invariant before adding a
+new running Session.
+
+### Completion
+
+A `Completion` is a binary signal for a Routine/date or Plan/date. Its natural
+identity is the target plus local date, so toggling it is idempotent and must
+not duplicate records. It has no Session foreign key. A user can:
+
+- track time without completing a Plan;
+- complete a Plan without tracking time;
+- spend more or less actual time than its planned duration.
+
+## Value and time semantics
+
+### Identity
+
+Routine, Plan, and Session IDs are opaque, stable strings owned by the
+application boundary that creates them. The core validates that they are
+non-empty but does not generate UUIDs or embed cloud/account ownership. A
+Completion uses a natural composite identity (`target`, `local date`) rather
+than an independently meaningful ID.
+
+### Date versus timestamp
+
+- A date is a local calendar date in the user's desktop timezone and is
+  represented canonically as `YYYY-MM-DD`.
+- A timestamp is an instant represented in the core as Unix seconds. The
+  desktop adapter may persist and exchange ISO-8601 strings, but parsing and
+  formatting belong outside the core.
+- Schedule eligibility, completion keys, Plan dates, and the legacy `date`
+  column use local dates. They must not be computed by converting a local day
+  through UTC.
+- Desktop v0.1 uses the machine's current local timezone. There is no stored
+  per-record timezone or cloud synchronization policy in this model.
+- A session's elapsed duration is timestamp-based, so daylight-saving or
+  midnight boundaries do not create artificial pauses or resets.
+
+### Planned and actual duration
+
+Planned duration is a positive whole-minute `PlannedDuration` value. Actual
+duration is a `TrackedDuration` derived from session timestamps and may be
+zero for a session shorter than one minute. They are separate types and
+separate facts; neither is inferred from Completion.
+
+## Invariants
+
+The core enforces these rules:
+
+1. Entity IDs are non-empty and remain stable after creation.
+2. Local dates are real Gregorian dates in canonical `YYYY-MM-DD` form.
+3. Planned duration is greater than zero and expressed in minutes.
+4. A Routine title is non-empty; its start date cannot precede its creation
+   local date.
+5. A custom schedule has at least one unique weekday.
+6. A Plan retains its original date and effective planned duration when it is
+   skipped or moved.
+7. A Session has a Routine or Plan association, and its end cannot precede its
+   start.
+8. Actual Session duration is derived from timestamps; running Sessions use a
+   supplied `now` instant for the calculation.
+9. There is at most one running Session in the desktop aggregate.
+10. Completion is independent of Sessions and planned duration.
+11. Archiving changes future eligibility only and preserves historical data.
+
+## Current desktop migration map
+
+The current desktop vocabulary is retained until the later migration issues
+can move adapters safely. The mapping below is the compatibility contract.
+
+| Current persisted record | Stable concept | Mapping |
+| --- | --- | --- |
+| `Task.id` | `RoutineId` | Preserve the exact existing ID. |
+| `Task.title`, `description` | Routine text | Preserve trimmed user content. |
+| `Task.durationMinutes` | Routine default planned duration | Preserve as positive whole minutes. |
+| `Task.category`, `daysOfWeek` | Routine schedule rule | Map weekday/weekend/daily/custom to the equivalent weekday set. |
+| `Task.startYmd` | Routine `starts_on` | Preserve the local date; the adapter keeps the existing created-date cutoff. |
+| `Task.createdAt` | Routine `created_at` | Parse the existing ISO instant; derive `created_on` in the desktop local timezone. |
+| `Task.isActive` | Routine state | `true` → Active, `false` → Archived. |
+| `Task.autoArchiveAfter` | Routine archive-after-completions limit | Preserve the optional positive threshold. |
+| `Task.repeatCount` | Routine finite-planning limit | Preserve as the legacy finite planning/backlog limit until scheduling extraction defines a more specific policy. |
+| `Completion(taskId, date)` | Routine/date Completion | Preserve the task ID as `RoutineId` and the local date. If a historical Plan is materialized, retain the optional Plan association. |
+| `TimeEntry.id` | `SessionId` | Preserve the exact existing entry ID. |
+| `TimeEntry.taskId` | Session `routine_id` | Preserve the task ID as `RoutineId`. |
+| `TimeEntry.date` | Session's historical Plan date | Use it to find or create the stable historical Plan for that routine/date. |
+| `TimeEntry.startedAt`, `endedAt` | Session timestamps | Parse the existing ISO instants. Preserve running state when `endedAt` is null. |
+| `TimeEntry.minutes` | Derived/cache compatibility field | Do not treat it as authoritative; recompute actual duration from timestamps. Invalid temporal rows must be reported/quarantined rather than silently discarded. |
+| `TaskDailyMemo` | Day-scoped routine/Plan note | Preserve `id`, text, update instant, routine ID, and local date. It remains adapter-owned metadata rather than a new core planning concept. |
+
+The existing schema has no Plan table. Migration therefore materializes a
+stable historical Plan (for example, `legacy-plan:{routine-id}:{date}`) for
+each distinct routine/date referenced by a Completion or Session. Future Plans
+are derived from the Routine schedule and are not fabricated for every date
+just because a routine exists. This preserves historical comparisons without
+inventing work the user never planned.
+
+Migration is non-destructive and idempotent: keep the existing database file
+and identifiers, add the new representation alongside the old data while it
+is validated, and only mark a record migrated after its Routine, historical
+Plan, Session, Completion, and memo mappings have committed successfully.
+Malformed legacy data must remain recoverable and be surfaced to the adapter
+or migration report; it must not be silently deleted.
+
+## Explicitly out of scope
+
+The model contains no users, accounts, teams, ownership, billing, cloud-sync
+metadata, CRDTs, HTTP concepts, or database types. Those concerns belong to
+future delivery or persistence adapters only.

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -74,15 +74,19 @@ truth. An end before the start is invalid. A session may cross local midnight;
 its plan/date association remains the one selected when the session started,
 while its elapsed interval still uses the complete timestamps.
 
-Desktop v0.1 permits at most one running Session across the application. A
-start operation must validate the collection-level invariant before adding a
-new running Session.
+Desktop v0.1 permits at most one running Session across the application. The
+core `start_session` operation validates the existing collection and the
+prospective session before insertion; `ensure_single_running_session` remains
+available for validating an already assembled collection.
 
 ### Completion
 
-A `Completion` is a binary signal for a Routine/date or Plan/date. Its natural
-identity is the target plus local date, so toggling it is idempotent and must
-not duplicate records. It has no Session foreign key. A user can:
+A `Completion` is a binary signal for a Routine/date or Plan/date. A historical
+completion may retain both its RoutineId and materialized PlanId, but its
+canonical toggle key is Routine/date whenever the routine is known. A
+standalone Plan completion uses Plan/date. Toggling by that canonical key is
+idempotent and must not duplicate records. It has no Session foreign key. A
+user can:
 
 - track time without completing a Plan;
 - complete a Plan without tracking time;
@@ -95,8 +99,9 @@ not duplicate records. It has no Session foreign key. A user can:
 Routine, Plan, and Session IDs are opaque, stable strings owned by the
 application boundary that creates them. The core validates that they are
 non-empty but does not generate UUIDs or embed cloud/account ownership. A
-Completion uses a natural composite identity (`target`, `local date`) rather
-than an independently meaningful ID.
+Completion uses a natural composite identity: Routine/date when a routine
+association exists, otherwise Plan/date. It does not need an independently
+meaningful ID.
 
 ### Date versus timestamp
 
@@ -156,7 +161,7 @@ can move adapters safely. The mapping below is the compatibility contract.
 | `Task.isActive` | Routine state | `true` → Active, `false` → Archived. |
 | `Task.autoArchiveAfter` | Routine archive-after-completions limit | Preserve the optional positive threshold. |
 | `Task.repeatCount` | Routine finite-planning limit | Preserve as the legacy finite planning/backlog limit until scheduling extraction defines a more specific policy. |
-| `Completion(taskId, date)` | Routine/date Completion | Preserve the task ID as `RoutineId` and the local date. If a historical Plan is materialized, retain the optional Plan association. |
+| `Completion(taskId, date)` | Routine/date Completion | Preserve the task ID as `RoutineId` and the local date. If a historical Plan is materialized, use the completion form that retains both IDs while keeping Routine/date as the canonical toggle key. |
 | `TimeEntry.id` | `SessionId` | Preserve the exact existing entry ID. |
 | `TimeEntry.taskId` | Session `routine_id` | Preserve the task ID as `RoutineId`. |
 | `TimeEntry.date` | Session's historical Plan date | Use it to find or create the stable historical Plan for that routine/date. |


### PR DESCRIPTION
## Summary

Closes #6

- Add dependency-free frilday-core domain types for Routine, Plan, Session, Completion, dates, timestamps, and durations.
- Enforce stable IDs, valid local dates, positive planned durations, session timestamp invariants, one running session, and independent completion toggling.
- Document domain semantics, timezone assumptions, archive behavior, and the non-destructive mapping from current Task/TimeEntry/Completion/memo records.
- Link the domain contract from the architecture documentation.
 
## Validation

- cargo fmt --manifest-path crates/frilday-core/Cargo.toml -- --check
- cargo test --manifest-path crates/frilday-core/Cargo.toml\n- cargo clippy --manifest-path crates/frilday-core/Cargo.toml --all-targets -- -D warnings
- cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml
- cargo test --manifest-path apps/server/Cargo.toml
- bun test
- bun run lint\n- bun run build
 
## Review follow-up

- Validate prospective sessions before insertion, preserving the single-running-session invariant.
- Derive schedule weekdays from the local date.
- Preserve routine and historical plan associations while using a canonical completion key.