### PR TITLE
refactor: move desktop persistence behind Tauri

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ cargo test --workspace
   desktop runtime.
 - The desktop React layer uses the Tauri adapter for schedule, completion,
   session, timer, and statistics calculations backed by `frilday-core`;
-  SQLite persistence remains local adapter code.
+  typed SQLite persistence commands are implemented by the Rust-side local
+  adapter.
 
 ## Desktop app
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -51,5 +51,7 @@ macOS bundle output:
 - the desktop runtime is local-first and does not require a local Axum server
 - schedule, completion, session, timer, and statistics rules run through the
   Tauri adapter backed by `crates/frilday-core`
-- SQLite persistence remains a desktop adapter concern
+- SQLite schema and typed persistence commands live in the Rust-side desktop
+  adapter; legacy localStorage data is imported transactionally into the
+  existing `daily_check.db`
 - broader direction is documented in [../../docs/ARCHITECTURE.md](../../docs/ARCHITECTURE.md)

--- a/apps/desktop/bun.lock
+++ b/apps/desktop/bun.lock
@@ -8,7 +8,6 @@
         "@tailwindcss/vite": "^4.2.1",
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-notification": "^2.3.3",
-        "@tauri-apps/plugin-sql": "^2.3.2",
         "@tauri-apps/plugin-store": "^2.4.2",
         "clsx": "^2.1.1",
         "lucide-react": "^0.575.0",
@@ -278,8 +277,6 @@
     "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.10.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6Cn7YpPFwzChy0ERz6djKEmUehWrYlM+xTaNzGPgZocw3BD7OfwfWHKVWxXzdjEW2KfKkHddfdxK1XXTYqBRLg=="],
 
     "@tauri-apps/plugin-notification": ["@tauri-apps/plugin-notification@2.3.3", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg=="],
-
-    "@tauri-apps/plugin-sql": ["@tauri-apps/plugin-sql@2.3.2", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-4VDXhcKXVpyh5KKpnTGAn6q2DikPHH+TXGh9ZDQzULmG/JEz1RDvzQStgBJKddiukRbYEZ8CGIA2kskx+T+PpA=="],
 
     "@tauri-apps/plugin-store": ["@tauri-apps/plugin-store@2.4.2", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-0ClHS50Oq9HEvLPhNzTNFxbWVOqoAp3dRvtewQBeqfIQ0z5m3JRnOISIn2ZVPCrQC0MyGyhTS9DWhHjpigQE7A=="],
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,7 +18,6 @@
     "@tailwindcss/vite": "^4.2.1",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-notification": "^2.3.3",
-    "@tauri-apps/plugin-sql": "^2.3.2",
     "@tauri-apps/plugin-store": "^2.4.2",
     "clsx": "^2.1.1",
     "lucide-react": "^0.575.0",

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -11,7 +11,19 @@ pub fn run() {
         .plugin(tauri_plugin_sql::Builder::default().build())
         .plugin(tauri_plugin_notification::init())
         .invoke_handler(tauri::generate_handler![
-            persistence::execute_app_transaction,
+            persistence::initialize_app_database,
+            persistence::load_app_data,
+            persistence::import_legacy_app_data,
+            persistence::save_task,
+            persistence::set_task_active,
+            persistence::delete_task,
+            persistence::set_completion,
+            persistence::save_time_entries,
+            persistence::save_task_daily_memo,
+            persistence::get_setting,
+            persistence::set_setting,
+            persistence::get_migration_marker,
+            persistence::set_migration_marker,
             core_commands::core_visible_schedule,
             core_commands::core_toggle_completion,
             core_commands::core_statistics,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -19,6 +19,7 @@ pub fn run() {
             persistence::delete_task,
             persistence::set_completion,
             persistence::save_time_entries,
+            persistence::save_auto_stop_transition,
             persistence::save_task_daily_memo,
             persistence::get_setting,
             persistence::set_setting,

--- a/apps/desktop/src-tauri/src/persistence.rs
+++ b/apps/desktop/src-tauri/src/persistence.rs
@@ -84,6 +84,13 @@ pub struct CompletionStateRequest {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct AutoStopTransitionRequest {
+    pub time_entries: Vec<TimeEntryRecord>,
+    pub completions: Vec<CompletionRecord>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SettingRequest {
     pub key: String,
     pub value: Value,
@@ -726,6 +733,35 @@ pub async fn save_time_entries(
         .map_err(|error| format!("Failed to commit app data transaction: {error}"))
 }
 
+async fn save_auto_stop_transition_to_pool(
+    pool: &SqlitePool,
+    request: &AutoStopTransitionRequest,
+) -> Result<(), String> {
+    let mut transaction = pool
+        .begin()
+        .await
+        .map_err(|error| format!("Failed to begin app data transaction: {error}"))?;
+    for entry in &request.time_entries {
+        insert_time_entry(&mut transaction, entry).await?;
+    }
+    for completion in &request.completions {
+        insert_completion(&mut transaction, completion).await?;
+    }
+    transaction
+        .commit()
+        .await
+        .map_err(|error| format!("Failed to commit app data transaction: {error}"))
+}
+
+#[tauri::command]
+pub async fn save_auto_stop_transition(
+    db_instances: State<'_, DbInstances>,
+    request: AutoStopTransitionRequest,
+) -> Result<(), String> {
+    let pool = database_pool(&db_instances).await?;
+    save_auto_stop_transition_to_pool(&pool, &request).await
+}
+
 #[tauri::command]
 pub async fn save_task_daily_memo(
     db_instances: State<'_, DbInstances>,
@@ -920,6 +956,80 @@ mod tests {
                 .unwrap();
             assert_eq!(count, 0);
             assert_eq!(migration_marker(&pool).await.unwrap(), None);
+        });
+    }
+
+    #[test]
+    fn auto_stop_transition_commits_entries_and_completions_together() {
+        tauri::async_runtime::block_on(async {
+            let pool = test_pool().await;
+            let request = AutoStopTransitionRequest {
+                time_entries: vec![TimeEntryRecord {
+                    id: "entry-1".to_owned(),
+                    task_id: "task-1".to_owned(),
+                    date: "2026-01-05".to_owned(),
+                    started_at: "2026-01-05T09:00:00.000Z".to_owned(),
+                    ended_at: Some("2026-01-05T09:30:00.000Z".to_owned()),
+                    minutes: 30,
+                }],
+                completions: vec![CompletionRecord {
+                    task_id: "task-1".to_owned(),
+                    date: "2026-01-05".to_owned(),
+                }],
+            };
+
+            save_auto_stop_transition_to_pool(&pool, &request)
+                .await
+                .unwrap();
+
+            let entries: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM time_entries")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+            let completions: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM completions")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+            assert_eq!(entries, 1);
+            assert_eq!(completions, 1);
+        });
+    }
+
+    #[test]
+    fn failed_auto_stop_transition_rolls_back_all_records() {
+        tauri::async_runtime::block_on(async {
+            let pool = test_pool().await;
+            sqlx::query(
+                "CREATE TRIGGER fail_auto_stop_completion
+                 BEFORE INSERT ON completions
+                 BEGIN SELECT RAISE(ABORT, 'completion insert failed'); END",
+            )
+            .execute(&pool)
+            .await
+            .unwrap();
+            let request = AutoStopTransitionRequest {
+                time_entries: vec![TimeEntryRecord {
+                    id: "entry-1".to_owned(),
+                    task_id: "task-1".to_owned(),
+                    date: "2026-01-05".to_owned(),
+                    started_at: "2026-01-05T09:00:00.000Z".to_owned(),
+                    ended_at: Some("2026-01-05T09:30:00.000Z".to_owned()),
+                    minutes: 30,
+                }],
+                completions: vec![CompletionRecord {
+                    task_id: "task-1".to_owned(),
+                    date: "2026-01-05".to_owned(),
+                }],
+            };
+
+            assert!(save_auto_stop_transition_to_pool(&pool, &request)
+                .await
+                .is_err());
+            let entries: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM time_entries")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+            assert_eq!(entries, 0);
         });
     }
 }

--- a/apps/desktop/src-tauri/src/persistence.rs
+++ b/apps/desktop/src-tauri/src/persistence.rs
@@ -1,69 +1,795 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use sqlx::{FromRow, Sqlite, SqlitePool, Transaction};
 use tauri::State;
 use tauri_plugin_sql::{DbInstances, DbPool};
 
-const DB_URL: &str = "sqlite:daily_check.db";
+pub const DB_URL: &str = "sqlite:daily_check.db";
+const LEGACY_STORAGE_MIGRATION_KEY: &str = "legacy_storage_migrated_v1";
 
-#[derive(Debug, Deserialize)]
-pub struct SqlStatement {
-    sql: String,
-    #[serde(default)]
-    bind: Vec<Value>,
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskRecord {
+    pub id: String,
+    pub title: String,
+    pub description: String,
+    pub category: String,
+    pub days_of_week: Vec<String>,
+    pub duration_minutes: u32,
+    pub start_ymd: Option<String>,
+    pub auto_archive_after: Option<u32>,
+    pub repeat_count: Option<u32>,
+    pub is_active: bool,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CompletionRecord {
+    pub task_id: String,
+    pub date: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct TimeEntryRecord {
+    pub id: String,
+    pub task_id: String,
+    pub date: String,
+    pub started_at: String,
+    pub ended_at: Option<String>,
+    pub minutes: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskDailyMemoRecord {
+    pub id: String,
+    pub task_id: String,
+    pub date: String,
+    pub text: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AppData {
+    pub tasks: Vec<TaskRecord>,
+    pub completions: Vec<CompletionRecord>,
+    pub time_entries: Vec<TimeEntryRecord>,
+    pub task_daily_memos: Vec<TaskDailyMemoRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LegacyMigrationOutput {
+    pub imported: bool,
+    pub skipped_existing_data: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskActiveRequest {
+    pub task_id: String,
+    pub is_active: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CompletionStateRequest {
+    pub task_id: String,
+    pub date: String,
+    pub completed: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SettingRequest {
+    pub key: String,
+    pub value: Value,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MetadataRequest {
+    pub key: String,
+    pub value: String,
+}
+
+#[derive(Debug, FromRow)]
+struct TaskRow {
+    id: String,
+    title: String,
+    description: String,
+    category: String,
+    days_of_week: String,
+    duration_minutes: i64,
+    start_ymd: Option<String>,
+    auto_archive_after: Option<i64>,
+    repeat_count: Option<i64>,
+    is_active: i64,
+    created_at: String,
+}
+
+#[derive(Debug, FromRow)]
+struct CompletionRow {
+    task_id: String,
+    date: String,
+}
+
+#[derive(Debug, FromRow)]
+struct TimeEntryRow {
+    id: String,
+    task_id: String,
+    date: String,
+    started_at: String,
+    ended_at: Option<String>,
+    minutes: i64,
+}
+
+#[derive(Debug, FromRow)]
+struct TaskDailyMemoRow {
+    id: String,
+    task_id: String,
+    date: String,
+    text: String,
+    updated_at: String,
+}
+
+#[derive(Debug, FromRow)]
+struct MetaRow {
+    value: String,
+}
+
+#[derive(Debug, FromRow)]
+struct SettingRow {
+    value: String,
+}
+
+async fn database_pool(db_instances: &DbInstances) -> Result<SqlitePool, String> {
+    let instances = db_instances.0.read().await;
+    match instances.get(DB_URL) {
+        Some(DbPool::Sqlite(pool)) => Ok(pool.clone()),
+        None => Err(format!("Database is not loaded: {DB_URL}")),
+    }
+}
+
+pub async fn initialize_schema(pool: &SqlitePool) -> Result<(), String> {
+    let statements = [
+        "CREATE TABLE IF NOT EXISTS settings_kv (key TEXT PRIMARY KEY, value TEXT NOT NULL)",
+        "CREATE TABLE IF NOT EXISTS app_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)",
+        "CREATE TABLE IF NOT EXISTS tasks (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            description TEXT NOT NULL,
+            category TEXT NOT NULL,
+            days_of_week TEXT NOT NULL,
+            duration_minutes INTEGER NOT NULL,
+            start_ymd TEXT,
+            auto_archive_after INTEGER,
+            repeat_count INTEGER,
+            is_active INTEGER NOT NULL,
+            created_at TEXT NOT NULL
+        )",
+        "CREATE TABLE IF NOT EXISTS completions (
+            task_id TEXT NOT NULL,
+            date TEXT NOT NULL,
+            PRIMARY KEY (task_id, date)
+        )",
+        "CREATE TABLE IF NOT EXISTS time_entries (
+            id TEXT PRIMARY KEY,
+            task_id TEXT NOT NULL,
+            date TEXT NOT NULL,
+            started_at TEXT NOT NULL,
+            ended_at TEXT,
+            minutes INTEGER NOT NULL
+        )",
+        "CREATE TABLE IF NOT EXISTS task_daily_memos (
+            id TEXT PRIMARY KEY,
+            task_id TEXT NOT NULL,
+            date TEXT NOT NULL,
+            text TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            UNIQUE (task_id, date)
+        )",
+    ];
+
+    for statement in statements {
+        sqlx::query(statement)
+            .execute(pool)
+            .await
+            .map_err(|error| format!("Failed to initialize app database: {error}"))?;
+    }
+
+    Ok(())
 }
 
 #[tauri::command]
-pub async fn execute_app_transaction(
-    db_instances: State<'_, DbInstances>,
-    statements: Vec<SqlStatement>,
-) -> Result<(), String> {
-    let pool = {
-        let instances = db_instances.0.read().await;
-        match instances.get(DB_URL) {
-            Some(DbPool::Sqlite(pool)) => pool.clone(),
-            None => return Err(format!("Database is not loaded: {DB_URL}")),
-        }
-    };
-
-    execute_transaction(&pool, statements).await
+pub async fn initialize_app_database(db_instances: State<'_, DbInstances>) -> Result<(), String> {
+    let pool = database_pool(&db_instances).await?;
+    initialize_schema(&pool).await
 }
 
-async fn execute_transaction(
-    pool: &sqlx::Pool<sqlx::Sqlite>,
-    statements: Vec<SqlStatement>,
+pub async fn load_app_data_from_pool(pool: &SqlitePool) -> Result<AppData, String> {
+    let task_rows = sqlx::query_as::<_, TaskRow>(
+        "SELECT id, title, description, category, days_of_week, duration_minutes,
+                start_ymd, auto_archive_after, repeat_count, is_active, created_at
+         FROM tasks ORDER BY created_at DESC",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|error| format!("Failed to load tasks: {error}"))?;
+
+    let completion_rows = sqlx::query_as::<_, CompletionRow>(
+        "SELECT task_id, date FROM completions ORDER BY date DESC, task_id ASC",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|error| format!("Failed to load completions: {error}"))?;
+
+    let time_entry_rows = sqlx::query_as::<_, TimeEntryRow>(
+        "SELECT id, task_id, date, started_at, ended_at, minutes
+         FROM time_entries ORDER BY started_at DESC",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|error| format!("Failed to load time entries: {error}"))?;
+
+    let memo_rows = sqlx::query_as::<_, TaskDailyMemoRow>(
+        "SELECT id, task_id, date, text, updated_at
+         FROM task_daily_memos ORDER BY updated_at DESC",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|error| format!("Failed to load daily memos: {error}"))?;
+
+    let tasks = task_rows
+        .into_iter()
+        .map(task_from_row)
+        .collect::<Result<Vec<_>, _>>()?;
+    let time_entries = time_entry_rows
+        .into_iter()
+        .map(time_entry_from_row)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(AppData {
+        tasks,
+        completions: completion_rows
+            .into_iter()
+            .map(|row| CompletionRecord {
+                task_id: row.task_id,
+                date: row.date,
+            })
+            .collect(),
+        time_entries,
+        task_daily_memos: memo_rows
+            .into_iter()
+            .map(|row| TaskDailyMemoRecord {
+                id: row.id,
+                task_id: row.task_id,
+                date: row.date,
+                text: row.text,
+                updated_at: row.updated_at,
+            })
+            .collect(),
+    })
+}
+
+fn task_from_row(row: TaskRow) -> Result<TaskRecord, String> {
+    let days_of_week = serde_json::from_str(&row.days_of_week)
+        .map_err(|error| format!("Failed to decode task schedule: {error}"))?;
+    Ok(TaskRecord {
+        id: row.id,
+        title: row.title,
+        description: row.description,
+        category: row.category,
+        days_of_week,
+        duration_minutes: u32::try_from(row.duration_minutes)
+            .map_err(|_| "Task duration is outside the supported range".to_owned())?,
+        start_ymd: row.start_ymd,
+        auto_archive_after: row
+            .auto_archive_after
+            .map(u32::try_from)
+            .transpose()
+            .map_err(|_| "Task archive threshold is invalid".to_owned())?,
+        repeat_count: row
+            .repeat_count
+            .map(u32::try_from)
+            .transpose()
+            .map_err(|_| "Task repeat count is invalid".to_owned())?,
+        is_active: row.is_active != 0,
+        created_at: row.created_at,
+    })
+}
+
+fn time_entry_from_row(row: TimeEntryRow) -> Result<TimeEntryRecord, String> {
+    Ok(TimeEntryRecord {
+        id: row.id,
+        task_id: row.task_id,
+        date: row.date,
+        started_at: row.started_at,
+        ended_at: row.ended_at,
+        minutes: u32::try_from(row.minutes)
+            .map_err(|_| "Time entry duration is outside the supported range".to_owned())?,
+    })
+}
+
+#[tauri::command]
+pub async fn load_app_data(db_instances: State<'_, DbInstances>) -> Result<AppData, String> {
+    let pool = database_pool(&db_instances).await?;
+    initialize_schema(&pool).await?;
+    load_app_data_from_pool(&pool).await
+}
+
+async fn set_meta(
+    executor: &mut Transaction<'_, Sqlite>,
+    key: &str,
+    value: &str,
 ) -> Result<(), String> {
+    sqlx::query(
+        "INSERT INTO app_meta (key, value) VALUES (?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    )
+    .bind(key)
+    .bind(value)
+    .execute(&mut **executor)
+    .await
+    .map(|_| ())
+    .map_err(|error| format!("Failed to save app metadata: {error}"))
+}
+
+async fn migration_marker(pool: &SqlitePool) -> Result<Option<String>, String> {
+    migration_marker_for_key(pool, LEGACY_STORAGE_MIGRATION_KEY).await
+}
+
+#[tauri::command]
+pub async fn get_migration_marker(
+    db_instances: State<'_, DbInstances>,
+    key: String,
+) -> Result<Option<String>, String> {
+    let pool = database_pool(&db_instances).await?;
+    migration_marker_for_key(&pool, &key).await
+}
+
+async fn migration_marker_for_key(pool: &SqlitePool, key: &str) -> Result<Option<String>, String> {
+    sqlx::query_as::<_, MetaRow>("SELECT value FROM app_meta WHERE key = ? LIMIT 1")
+        .bind(key)
+        .fetch_optional(pool)
+        .await
+        .map(|row| row.map(|row| row.value))
+        .map_err(|error| format!("Failed to read app metadata: {error}"))
+}
+
+#[tauri::command]
+pub async fn set_migration_marker(
+    db_instances: State<'_, DbInstances>,
+    request: MetadataRequest,
+) -> Result<(), String> {
+    let pool = database_pool(&db_instances).await?;
+    sqlx::query(
+        "INSERT INTO app_meta (key, value) VALUES (?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    )
+    .bind(request.key)
+    .bind(request.value)
+    .execute(&pool)
+    .await
+    .map(|_| ())
+    .map_err(|error| format!("Failed to save app metadata: {error}"))
+}
+
+async fn has_existing_data(pool: &SqlitePool) -> Result<bool, String> {
+    let tables = ["tasks", "completions", "time_entries", "task_daily_memos"];
+    for table in tables {
+        let query = format!("SELECT EXISTS(SELECT 1 FROM {table} LIMIT 1)");
+        let has_rows: i64 = sqlx::query_scalar(&query)
+            .fetch_one(pool)
+            .await
+            .map_err(|error| format!("Failed to inspect existing app data: {error}"))?;
+        if has_rows != 0 {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+async fn insert_task(
+    executor: &mut Transaction<'_, Sqlite>,
+    task: &TaskRecord,
+) -> Result<(), String> {
+    let days_of_week = serde_json::to_string(&task.days_of_week)
+        .map_err(|error| format!("Failed to encode task schedule: {error}"))?;
+    sqlx::query(
+        "INSERT INTO tasks (
+            id, title, description, category, days_of_week, duration_minutes,
+            start_ymd, auto_archive_after, repeat_count, is_active, created_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+            title = excluded.title,
+            description = excluded.description,
+            category = excluded.category,
+            days_of_week = excluded.days_of_week,
+            duration_minutes = excluded.duration_minutes,
+            start_ymd = excluded.start_ymd,
+            auto_archive_after = excluded.auto_archive_after,
+            repeat_count = excluded.repeat_count,
+            is_active = excluded.is_active,
+            created_at = excluded.created_at",
+    )
+    .bind(&task.id)
+    .bind(&task.title)
+    .bind(&task.description)
+    .bind(&task.category)
+    .bind(days_of_week)
+    .bind(i64::from(task.duration_minutes))
+    .bind(&task.start_ymd)
+    .bind(task.auto_archive_after.map(i64::from))
+    .bind(task.repeat_count.map(i64::from))
+    .bind(if task.is_active { 1_i64 } else { 0_i64 })
+    .bind(&task.created_at)
+    .execute(&mut **executor)
+    .await
+    .map(|_| ())
+    .map_err(|error| format!("Failed to save task: {error}"))
+}
+
+async fn insert_task_if_absent(
+    executor: &mut Transaction<'_, Sqlite>,
+    task: &TaskRecord,
+) -> Result<(), String> {
+    let days_of_week = serde_json::to_string(&task.days_of_week)
+        .map_err(|error| format!("Failed to encode task schedule: {error}"))?;
+    sqlx::query(
+        "INSERT INTO tasks (
+            id, title, description, category, days_of_week, duration_minutes,
+            start_ymd, auto_archive_after, repeat_count, is_active, created_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO NOTHING",
+    )
+    .bind(&task.id)
+    .bind(&task.title)
+    .bind(&task.description)
+    .bind(&task.category)
+    .bind(days_of_week)
+    .bind(i64::from(task.duration_minutes))
+    .bind(&task.start_ymd)
+    .bind(task.auto_archive_after.map(i64::from))
+    .bind(task.repeat_count.map(i64::from))
+    .bind(if task.is_active { 1_i64 } else { 0_i64 })
+    .bind(&task.created_at)
+    .execute(&mut **executor)
+    .await
+    .map(|_| ())
+    .map_err(|error| format!("Failed to import task: {error}"))
+}
+
+async fn insert_completion(
+    executor: &mut Transaction<'_, Sqlite>,
+    completion: &CompletionRecord,
+) -> Result<(), String> {
+    sqlx::query("INSERT INTO completions (task_id, date) VALUES (?, ?) ON CONFLICT DO NOTHING")
+        .bind(&completion.task_id)
+        .bind(&completion.date)
+        .execute(&mut **executor)
+        .await
+        .map(|_| ())
+        .map_err(|error| format!("Failed to save completion: {error}"))
+}
+
+async fn insert_time_entry(
+    executor: &mut Transaction<'_, Sqlite>,
+    entry: &TimeEntryRecord,
+) -> Result<(), String> {
+    sqlx::query(
+        "INSERT INTO time_entries (id, task_id, date, started_at, ended_at, minutes)
+         VALUES (?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+            task_id = excluded.task_id,
+            date = excluded.date,
+            started_at = excluded.started_at,
+            ended_at = excluded.ended_at,
+            minutes = excluded.minutes",
+    )
+    .bind(&entry.id)
+    .bind(&entry.task_id)
+    .bind(&entry.date)
+    .bind(&entry.started_at)
+    .bind(&entry.ended_at)
+    .bind(i64::from(entry.minutes))
+    .execute(&mut **executor)
+    .await
+    .map(|_| ())
+    .map_err(|error| format!("Failed to save time entry: {error}"))
+}
+
+async fn insert_time_entry_if_absent(
+    executor: &mut Transaction<'_, Sqlite>,
+    entry: &TimeEntryRecord,
+) -> Result<(), String> {
+    sqlx::query(
+        "INSERT INTO time_entries (id, task_id, date, started_at, ended_at, minutes)
+         VALUES (?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO NOTHING",
+    )
+    .bind(&entry.id)
+    .bind(&entry.task_id)
+    .bind(&entry.date)
+    .bind(&entry.started_at)
+    .bind(&entry.ended_at)
+    .bind(i64::from(entry.minutes))
+    .execute(&mut **executor)
+    .await
+    .map(|_| ())
+    .map_err(|error| format!("Failed to import time entry: {error}"))
+}
+
+async fn insert_memo(
+    executor: &mut Transaction<'_, Sqlite>,
+    memo: &TaskDailyMemoRecord,
+) -> Result<(), String> {
+    sqlx::query(
+        "INSERT INTO task_daily_memos (id, task_id, date, text, updated_at)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(task_id, date) DO UPDATE SET
+            id = excluded.id,
+            text = excluded.text,
+            updated_at = excluded.updated_at",
+    )
+    .bind(&memo.id)
+    .bind(&memo.task_id)
+    .bind(&memo.date)
+    .bind(&memo.text)
+    .bind(&memo.updated_at)
+    .execute(&mut **executor)
+    .await
+    .map(|_| ())
+    .map_err(|error| format!("Failed to save daily memo: {error}"))
+}
+
+async fn insert_memo_if_absent(
+    executor: &mut Transaction<'_, Sqlite>,
+    memo: &TaskDailyMemoRecord,
+) -> Result<(), String> {
+    sqlx::query(
+        "INSERT INTO task_daily_memos (id, task_id, date, text, updated_at)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(task_id, date) DO NOTHING",
+    )
+    .bind(&memo.id)
+    .bind(&memo.task_id)
+    .bind(&memo.date)
+    .bind(&memo.text)
+    .bind(&memo.updated_at)
+    .execute(&mut **executor)
+    .await
+    .map(|_| ())
+    .map_err(|error| format!("Failed to import daily memo: {error}"))
+}
+
+async fn import_app_data(
+    pool: &SqlitePool,
+    data: &AppData,
+) -> Result<LegacyMigrationOutput, String> {
+    if migration_marker(pool).await?.as_deref() == Some("1") {
+        return Ok(LegacyMigrationOutput {
+            imported: false,
+            skipped_existing_data: false,
+        });
+    }
+
+    let skipped_existing_data = has_existing_data(pool).await?;
+
+    let mut transaction = pool
+        .begin()
+        .await
+        .map_err(|error| format!("Failed to begin migration transaction: {error}"))?;
+
+    for task in &data.tasks {
+        insert_task_if_absent(&mut transaction, task).await?;
+    }
+    for completion in &data.completions {
+        insert_completion(&mut transaction, completion).await?;
+    }
+    for entry in &data.time_entries {
+        insert_time_entry_if_absent(&mut transaction, entry).await?;
+    }
+    for memo in &data.task_daily_memos {
+        insert_memo_if_absent(&mut transaction, memo).await?;
+    }
+    set_meta(&mut transaction, LEGACY_STORAGE_MIGRATION_KEY, "1").await?;
+    transaction
+        .commit()
+        .await
+        .map_err(|error| format!("Failed to commit data migration: {error}"))?;
+
+    Ok(LegacyMigrationOutput {
+        imported: !data.tasks.is_empty()
+            || !data.completions.is_empty()
+            || !data.time_entries.is_empty()
+            || !data.task_daily_memos.is_empty(),
+        skipped_existing_data,
+    })
+}
+
+#[tauri::command]
+pub async fn import_legacy_app_data(
+    db_instances: State<'_, DbInstances>,
+    data: AppData,
+) -> Result<LegacyMigrationOutput, String> {
+    let pool = database_pool(&db_instances).await?;
+    initialize_schema(&pool).await?;
+    import_app_data(&pool, &data).await
+}
+
+#[tauri::command]
+pub async fn save_task(
+    db_instances: State<'_, DbInstances>,
+    task: TaskRecord,
+) -> Result<(), String> {
+    let pool = database_pool(&db_instances).await?;
     let mut transaction = pool
         .begin()
         .await
         .map_err(|error| format!("Failed to begin app data transaction: {error}"))?;
-
-    for (index, statement) in statements.into_iter().enumerate() {
-        let mut query = sqlx::query(&statement.sql);
-        for value in statement.bind {
-            if value.is_null() {
-                query = query.bind(None::<Value>);
-            } else if value.is_string() {
-                query = query.bind(value.as_str().unwrap_or_default().to_owned());
-            } else if let Some(number) = value.as_number() {
-                query = query.bind(number.as_f64().unwrap_or_default());
-            } else {
-                query = query.bind(value);
-            }
-        }
-
-        if let Err(error) = query.execute(&mut *transaction).await {
-            let message = format!("Failed to execute app data statement {index}: {error}");
-            if let Err(rollback_error) = transaction.rollback().await {
-                return Err(format!("{message}; rollback failed: {rollback_error}"));
-            }
-            return Err(message);
-        }
-    }
-
+    insert_task(&mut transaction, &task).await?;
     transaction
         .commit()
         .await
         .map_err(|error| format!("Failed to commit app data transaction: {error}"))
+}
+
+#[tauri::command]
+pub async fn set_task_active(
+    db_instances: State<'_, DbInstances>,
+    request: TaskActiveRequest,
+) -> Result<(), String> {
+    let pool = database_pool(&db_instances).await?;
+    sqlx::query("UPDATE tasks SET is_active = ? WHERE id = ?")
+        .bind(if request.is_active { 1_i64 } else { 0_i64 })
+        .bind(request.task_id)
+        .execute(&pool)
+        .await
+        .map(|_| ())
+        .map_err(|error| format!("Failed to update task state: {error}"))
+}
+
+#[tauri::command]
+pub async fn delete_task(
+    db_instances: State<'_, DbInstances>,
+    task_id: String,
+) -> Result<(), String> {
+    let pool = database_pool(&db_instances).await?;
+    let mut transaction = pool
+        .begin()
+        .await
+        .map_err(|error| format!("Failed to begin app data transaction: {error}"))?;
+    for table in ["completions", "time_entries", "task_daily_memos"] {
+        let query = format!("DELETE FROM {table} WHERE task_id = ?");
+        sqlx::query(&query)
+            .bind(&task_id)
+            .execute(&mut *transaction)
+            .await
+            .map_err(|error| format!("Failed to delete task data: {error}"))?;
+    }
+    sqlx::query("DELETE FROM tasks WHERE id = ?")
+        .bind(task_id)
+        .execute(&mut *transaction)
+        .await
+        .map_err(|error| format!("Failed to delete task: {error}"))?;
+    transaction
+        .commit()
+        .await
+        .map_err(|error| format!("Failed to commit app data transaction: {error}"))
+}
+
+#[tauri::command]
+pub async fn set_completion(
+    db_instances: State<'_, DbInstances>,
+    request: CompletionStateRequest,
+) -> Result<(), String> {
+    let pool = database_pool(&db_instances).await?;
+    if request.completed {
+        sqlx::query("INSERT INTO completions (task_id, date) VALUES (?, ?) ON CONFLICT DO NOTHING")
+            .bind(request.task_id)
+            .bind(request.date)
+            .execute(&pool)
+            .await
+            .map(|_| ())
+            .map_err(|error| format!("Failed to save completion: {error}"))
+    } else {
+        sqlx::query("DELETE FROM completions WHERE task_id = ? AND date = ?")
+            .bind(request.task_id)
+            .bind(request.date)
+            .execute(&pool)
+            .await
+            .map(|_| ())
+            .map_err(|error| format!("Failed to remove completion: {error}"))
+    }
+}
+
+#[tauri::command]
+pub async fn save_time_entries(
+    db_instances: State<'_, DbInstances>,
+    entries: Vec<TimeEntryRecord>,
+) -> Result<(), String> {
+    let pool = database_pool(&db_instances).await?;
+    let mut transaction = pool
+        .begin()
+        .await
+        .map_err(|error| format!("Failed to begin app data transaction: {error}"))?;
+    for entry in &entries {
+        insert_time_entry(&mut transaction, entry).await?;
+    }
+    transaction
+        .commit()
+        .await
+        .map_err(|error| format!("Failed to commit app data transaction: {error}"))
+}
+
+#[tauri::command]
+pub async fn save_task_daily_memo(
+    db_instances: State<'_, DbInstances>,
+    memo: TaskDailyMemoRecord,
+) -> Result<(), String> {
+    let pool = database_pool(&db_instances).await?;
+    if memo.text.trim().is_empty() {
+        sqlx::query("DELETE FROM task_daily_memos WHERE task_id = ? AND date = ?")
+            .bind(memo.task_id)
+            .bind(memo.date)
+            .execute(&pool)
+            .await
+            .map(|_| ())
+            .map_err(|error| format!("Failed to remove daily memo: {error}"))
+    } else {
+        let mut transaction = pool
+            .begin()
+            .await
+            .map_err(|error| format!("Failed to begin app data transaction: {error}"))?;
+        insert_memo(&mut transaction, &memo).await?;
+        transaction
+            .commit()
+            .await
+            .map_err(|error| format!("Failed to commit app data transaction: {error}"))
+    }
+}
+
+#[tauri::command]
+pub async fn get_setting(
+    db_instances: State<'_, DbInstances>,
+    key: String,
+) -> Result<Option<Value>, String> {
+    let pool = database_pool(&db_instances).await?;
+    let row =
+        sqlx::query_as::<_, SettingRow>("SELECT value FROM settings_kv WHERE key = ? LIMIT 1")
+            .bind(key)
+            .fetch_optional(&pool)
+            .await
+            .map_err(|error| format!("Failed to load setting: {error}"))?;
+
+    match row {
+        Some(row) => Ok(serde_json::from_str(&row.value).ok()),
+        None => Ok(None),
+    }
+}
+
+#[tauri::command]
+pub async fn set_setting(
+    db_instances: State<'_, DbInstances>,
+    request: SettingRequest,
+) -> Result<(), String> {
+    let pool = database_pool(&db_instances).await?;
+    let value = serde_json::to_string(&request.value)
+        .map_err(|error| format!("Failed to encode setting: {error}"))?;
+    sqlx::query(
+        "INSERT INTO settings_kv (key, value) VALUES (?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    )
+    .bind(request.key)
+    .bind(value)
+    .execute(&pool)
+    .await
+    .map(|_| ())
+    .map_err(|error| format!("Failed to save setting: {error}"))
 }
 
 #[cfg(test)]
@@ -71,31 +797,76 @@ mod tests {
     use super::*;
     use sqlx::sqlite::SqlitePoolOptions;
 
-    #[test]
-    fn commits_all_statements_as_one_transaction() {
-        tauri::async_runtime::block_on(async {
-            let pool = SqlitePoolOptions::new()
-                .max_connections(1)
-                .connect("sqlite::memory:")
-                .await
-                .unwrap();
+    fn sample_data() -> AppData {
+        AppData {
+            tasks: vec![TaskRecord {
+                id: "task-1".to_owned(),
+                title: "Focus".to_owned(),
+                description: "".to_owned(),
+                category: "weekday".to_owned(),
+                days_of_week: vec!["Mon".to_owned(), "Wed".to_owned()],
+                duration_minutes: 30,
+                start_ymd: None,
+                auto_archive_after: None,
+                repeat_count: None,
+                is_active: true,
+                created_at: "2026-01-01T00:00:00.000Z".to_owned(),
+            }],
+            completions: vec![CompletionRecord {
+                task_id: "task-1".to_owned(),
+                date: "2026-01-05".to_owned(),
+            }],
+            time_entries: vec![TimeEntryRecord {
+                id: "entry-1".to_owned(),
+                task_id: "task-1".to_owned(),
+                date: "2026-01-05".to_owned(),
+                started_at: "2026-01-05T09:00:00.000Z".to_owned(),
+                ended_at: Some("2026-01-05T09:30:00.000Z".to_owned()),
+                minutes: 30,
+            }],
+            task_daily_memos: vec![TaskDailyMemoRecord {
+                id: "task-1_2026-01-05".to_owned(),
+                task_id: "task-1".to_owned(),
+                date: "2026-01-05".to_owned(),
+                text: "Good focus".to_owned(),
+                updated_at: "2026-01-05T09:30:00.000Z".to_owned(),
+            }],
+        }
+    }
 
-            sqlx::query("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
-                .execute(&pool)
-                .await
-                .unwrap();
-
-            execute_transaction(
-                &pool,
-                vec![SqlStatement {
-                    sql: "INSERT INTO items (name) VALUES (?)".to_owned(),
-                    bind: vec![Value::String("saved".to_owned())],
-                }],
-            )
+    async fn test_pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
             .await
             .unwrap();
+        initialize_schema(&pool).await.unwrap();
+        pool
+    }
 
-            let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM items")
+    #[test]
+    fn imports_and_loads_all_desktop_records() {
+        tauri::async_runtime::block_on(async {
+            let pool = test_pool().await;
+            let data = sample_data();
+
+            let result = import_app_data(&pool, &data).await.unwrap();
+            assert_eq!(result.imported, true);
+            assert_eq!(load_app_data_from_pool(&pool).await.unwrap(), data);
+        });
+    }
+
+    #[test]
+    fn migration_is_idempotent_and_does_not_duplicate_records() {
+        tauri::async_runtime::block_on(async {
+            let pool = test_pool().await;
+            let data = sample_data();
+
+            import_app_data(&pool, &data).await.unwrap();
+            let second = import_app_data(&pool, &data).await.unwrap();
+            assert_eq!(second.imported, false);
+
+            let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM tasks")
                 .fetch_one(&pool)
                 .await
                 .unwrap();
@@ -104,40 +875,51 @@ mod tests {
     }
 
     #[test]
-    fn rolls_back_all_statements_when_one_fails() {
+    fn existing_database_wins_over_legacy_import() {
         tauri::async_runtime::block_on(async {
-            let pool = SqlitePoolOptions::new()
-                .max_connections(1)
-                .connect("sqlite::memory:")
-                .await
-                .unwrap();
+            let pool = test_pool().await;
+            let existing = TaskRecord {
+                id: "existing".to_owned(),
+                title: "Existing".to_owned(),
+                description: "".to_owned(),
+                category: "daily".to_owned(),
+                days_of_week: vec!["Mon".to_owned()],
+                duration_minutes: 10,
+                start_ymd: None,
+                auto_archive_after: None,
+                repeat_count: None,
+                is_active: true,
+                created_at: "2026-01-01T00:00:00.000Z".to_owned(),
+            };
+            let mut transaction = pool.begin().await.unwrap();
+            insert_task(&mut transaction, &existing).await.unwrap();
+            transaction.commit().await.unwrap();
 
-            sqlx::query("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+            let result = import_app_data(&pool, &sample_data()).await.unwrap();
+            assert_eq!(result.skipped_existing_data, true);
+            let loaded = load_app_data_from_pool(&pool).await.unwrap();
+            assert_eq!(loaded.tasks.len(), 2);
+            assert!(loaded.tasks.iter().any(|task| task.id == "existing"));
+            assert!(loaded.tasks.iter().any(|task| task.id == "task-1"));
+        });
+    }
+
+    #[test]
+    fn failed_import_rolls_back_without_marking_migration_complete() {
+        tauri::async_runtime::block_on(async {
+            let pool = test_pool().await;
+            sqlx::query("DROP TABLE task_daily_memos")
                 .execute(&pool)
                 .await
                 .unwrap();
 
-            let result = execute_transaction(
-                &pool,
-                vec![
-                    SqlStatement {
-                        sql: "INSERT INTO items (name) VALUES (?)".to_owned(),
-                        bind: vec![Value::String("rolled back".to_owned())],
-                    },
-                    SqlStatement {
-                        sql: "INSERT INTO missing (name) VALUES (?)".to_owned(),
-                        bind: vec![Value::String("failure".to_owned())],
-                    },
-                ],
-            )
-            .await;
-
-            assert!(result.is_err());
-            let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM items")
+            assert!(import_app_data(&pool, &sample_data()).await.is_err());
+            let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM tasks")
                 .fetch_one(&pool)
                 .await
                 .unwrap();
             assert_eq!(count, 0);
+            assert_eq!(migration_marker(&pool).await.unwrap(), None);
         });
     }
 }

--- a/apps/desktop/src/app/store/useFrilDayStore.ts
+++ b/apps/desktop/src/app/store/useFrilDayStore.ts
@@ -7,7 +7,15 @@ import type {
   TaskDailyMemo,
   TimeEntry,
 } from '../../shared/types';
-import { loadAppData, replaceAllAppData } from '../../infrastructure/storage';
+import {
+  deleteTask as deletePersistedTask,
+  loadAppData,
+  saveTask,
+  saveTaskDailyMemo,
+  saveTimeEntries,
+  setCompletion,
+  setTaskActive,
+} from '../../infrastructure/storage';
 import { toYmd } from '../../shared/utils/date';
 import { createSerialQueue } from '../../shared/utils/serialQueue';
 import { createTaskEntity } from '../../domain/task/taskFactory';
@@ -21,11 +29,6 @@ import {
 } from '../../infrastructure/tauri/core';
 
 export type Filter = 'all' | Category;
-
-type PersistedCollections = Pick<
-  FrilDayState,
-  'tasks' | 'completions' | 'timeEntries' | 'taskDailyMemos'
->;
 
 interface FrilDayState {
   hydrated: boolean;
@@ -88,11 +91,11 @@ function formatError(error: unknown): string {
   }
 }
 
-function persistCollections(
-  next: PersistedCollections,
+function persist(
+  operation: Promise<void>,
   failureMessage: string,
 ): void {
-  void replaceAllAppData(next).catch((error) => {
+  void operation.catch((error) => {
     console.error(failureMessage, error);
     useFrilDayStore.setState({
       errorMsg: `${failureMessage} ${formatError(error)}`,
@@ -170,15 +173,9 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
       });
 
       const nextTasks = [task, ...get().tasks];
-      const next = {
-        tasks: nextTasks,
-        completions: get().completions,
-        timeEntries: get().timeEntries,
-        taskDailyMemos: get().taskDailyMemos,
-      };
 
       set({ tasks: nextTasks, errorMsg: '' });
-      persistCollections(next, 'Failed to save task.');
+      persist(saveTask(task), 'Failed to save task.');
     } catch (e) {
       set({
         errorMsg: e instanceof Error ? e.message : 'Failed to create task.',
@@ -239,46 +236,28 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
           }
         : task,
     );
-
-    const next = {
-      tasks: nextTasks,
-      completions: get().completions,
-      timeEntries: get().timeEntries,
-      taskDailyMemos: get().taskDailyMemos,
-    };
+    const nextTask = nextTasks.find((task) => task.id === taskId);
 
     set({ tasks: nextTasks, errorMsg: '' });
-    persistCollections(next, 'Failed to update task.');
+    if (nextTask) persist(saveTask(nextTask), 'Failed to update task.');
   },
 
   archiveTask: (taskId) => {
     const nextTasks = get().tasks.map((t) =>
       t.id === taskId ? { ...t, isActive: false } : t,
     );
-    const next = {
-      tasks: nextTasks,
-      completions: get().completions,
-      timeEntries: get().timeEntries,
-      taskDailyMemos: get().taskDailyMemos,
-    };
 
     set({ tasks: nextTasks, errorMsg: '' });
-    persistCollections(next, 'Failed to archive task.');
+    persist(setTaskActive(taskId, false), 'Failed to archive task.');
   },
 
   restoreTask: (taskId) => {
     const nextTasks = get().tasks.map((t) =>
       t.id === taskId ? { ...t, isActive: true } : t,
     );
-    const next = {
-      tasks: nextTasks,
-      completions: get().completions,
-      timeEntries: get().timeEntries,
-      taskDailyMemos: get().taskDailyMemos,
-    };
 
     set({ tasks: nextTasks, errorMsg: '' });
-    persistCollections(next, 'Failed to restore task.');
+    persist(setTaskActive(taskId, true), 'Failed to restore task.');
   },
 
   deleteTask: (taskId) => {
@@ -291,18 +270,14 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
     );
     const nextMemos = get().taskDailyMemos.filter((m) => m.taskId !== taskId);
 
-    const next = {
+    set({
       tasks: nextTasks,
       completions: nextCompletions,
       timeEntries: nextTimeEntries,
       taskDailyMemos: nextMemos,
-    };
-
-    set({
-      ...next,
       errorMsg: '',
     });
-    persistCollections(next, 'Failed to delete task.');
+    persist(deletePersistedTask(taskId), 'Failed to delete task.');
   },
 
   toggleToday: ({ taskId, today }) =>
@@ -339,29 +314,46 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
         };
 
         set({ ...next, errorMsg: '' });
-        persistCollections(next, 'Failed to update completion.');
+        persist(
+          Promise.all([
+            setCompletion(
+              taskId,
+              date,
+              result.completions.some(
+                (completion) =>
+                  completion.taskId === taskId && completion.date === date,
+              ),
+            ),
+            ...(result.autoArchived
+              ? [setTaskActive(taskId, false)]
+              : []),
+          ]).then(() => undefined),
+          'Failed to update completion.',
+        );
       } catch (error) {
         set({ errorMsg: `Failed to update completion. ${formatError(error)}` });
       }
     }),
 
   setDailyMemo: ({ taskId, date, text }) => {
+    const updatedAt = new Date().toISOString();
     const nextMemos = upsertDailyMemo(get().taskDailyMemos, {
       taskId,
       date,
       text,
-      updatedAt: new Date().toISOString(),
+      updatedAt,
     });
 
-    const next = {
-      tasks: get().tasks,
-      completions: get().completions,
-      timeEntries: get().timeEntries,
-      taskDailyMemos: nextMemos,
+    const memo = {
+      id: `${taskId}_${date}`,
+      taskId,
+      date,
+      text: text.trim(),
+      updatedAt,
     };
 
     set({ taskDailyMemos: nextMemos, errorMsg: '' });
-    persistCollections(next, 'Failed to save memo.');
+    persist(saveTaskDailyMemo(memo), 'Failed to save memo.');
   },
 
   startTimer: async ({ taskId, today }) => {
@@ -377,15 +369,8 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
         dateYmd: date,
         startedAt: nowIso,
       });
-      const next = {
-        tasks: get().tasks,
-        completions: get().completions,
-        timeEntries: nextTimeEntries,
-        taskDailyMemos: get().taskDailyMemos,
-      };
-
       set({ timeEntries: nextTimeEntries, errorMsg: '' });
-      persistCollections(next, 'Failed to start timer.');
+      persist(saveTimeEntries(nextTimeEntries), 'Failed to start timer.');
     } catch (error) {
       set({ errorMsg: `Failed to start timer. ${formatError(error)}` });
     }
@@ -401,15 +386,8 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
         dateYmd: date,
         endedAt: nowIso,
       });
-      const next = {
-        tasks: get().tasks,
-        completions: get().completions,
-        timeEntries: nextTimeEntries,
-        taskDailyMemos: get().taskDailyMemos,
-      };
-
       set({ timeEntries: nextTimeEntries, errorMsg: '' });
-      persistCollections(next, 'Failed to stop timer.');
+      persist(saveTimeEntries(nextTimeEntries), 'Failed to stop timer.');
     } catch (error) {
       set({ errorMsg: `Failed to stop timer. ${formatError(error)}` });
     }
@@ -449,19 +427,30 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
       }
     }
 
-    const next = {
-      tasks: get().tasks,
-      completions: result.completions,
-      timeEntries: result.timeEntries,
-      taskDailyMemos: get().taskDailyMemos,
-    };
+    const previousCompletions = get().completions;
+    const addedCompletions = result.completions.filter(
+      (completion) =>
+        !previousCompletions.some(
+          (previous) =>
+            previous.taskId === completion.taskId &&
+            previous.date === completion.date,
+        ),
+    );
 
     set({
       timeEntries: result.timeEntries,
       completions: result.completions,
       errorMsg: '',
     });
-    persistCollections(next, 'Failed to auto-stop timer.');
+    persist(
+      Promise.all([
+        saveTimeEntries(result.timeEntries),
+        ...addedCompletions.map((completion) =>
+          setCompletion(completion.taskId, completion.date, true),
+        ),
+      ]).then(() => undefined),
+      'Failed to auto-stop timer.',
+    );
 
     return result.finishedTasks.map((finishedTask) => finishedTask.title);
   },

--- a/apps/desktop/src/app/store/useFrilDayStore.ts
+++ b/apps/desktop/src/app/store/useFrilDayStore.ts
@@ -11,13 +11,17 @@ import {
   deleteTask as deletePersistedTask,
   loadAppData,
   saveTask,
+  saveAutoStopTransition,
   saveTaskDailyMemo,
   saveTimeEntries,
   setCompletion,
   setTaskActive,
 } from '../../infrastructure/storage';
 import { toYmd } from '../../shared/utils/date';
-import { createSerialQueue } from '../../shared/utils/serialQueue';
+import {
+  createSerialQueue,
+  type AsyncOperation,
+} from '../../shared/utils/serialQueue';
 import { createTaskEntity } from '../../domain/task/taskFactory';
 import { getNotifier } from '../di/notifierDI';
 import { upsertDailyMemo } from '../../domain/memo';
@@ -92,10 +96,10 @@ function formatError(error: unknown): string {
 }
 
 function persist(
-  operation: Promise<void>,
+  operation: AsyncOperation,
   failureMessage: string,
 ): void {
-  void operation.catch((error) => {
+  void enqueuePersistence(operation).catch((error) => {
     console.error(failureMessage, error);
     useFrilDayStore.setState({
       errorMsg: `${failureMessage} ${formatError(error)}`,
@@ -103,6 +107,7 @@ function persist(
   });
 }
 
+const enqueuePersistence = createSerialQueue();
 const enqueueCompletionToggle = createSerialQueue();
 
 export const useFrilDayStore = create<FrilDayState>((set, get) => ({
@@ -175,7 +180,7 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
       const nextTasks = [task, ...get().tasks];
 
       set({ tasks: nextTasks, errorMsg: '' });
-      persist(saveTask(task), 'Failed to save task.');
+      persist(() => saveTask(task), 'Failed to save task.');
     } catch (e) {
       set({
         errorMsg: e instanceof Error ? e.message : 'Failed to create task.',
@@ -239,7 +244,7 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
     const nextTask = nextTasks.find((task) => task.id === taskId);
 
     set({ tasks: nextTasks, errorMsg: '' });
-    if (nextTask) persist(saveTask(nextTask), 'Failed to update task.');
+    if (nextTask) persist(() => saveTask(nextTask), 'Failed to update task.');
   },
 
   archiveTask: (taskId) => {
@@ -248,7 +253,10 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
     );
 
     set({ tasks: nextTasks, errorMsg: '' });
-    persist(setTaskActive(taskId, false), 'Failed to archive task.');
+    persist(
+      () => setTaskActive(taskId, false),
+      'Failed to archive task.',
+    );
   },
 
   restoreTask: (taskId) => {
@@ -257,7 +265,10 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
     );
 
     set({ tasks: nextTasks, errorMsg: '' });
-    persist(setTaskActive(taskId, true), 'Failed to restore task.');
+    persist(
+      () => setTaskActive(taskId, true),
+      'Failed to restore task.',
+    );
   },
 
   deleteTask: (taskId) => {
@@ -277,7 +288,7 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
       taskDailyMemos: nextMemos,
       errorMsg: '',
     });
-    persist(deletePersistedTask(taskId), 'Failed to delete task.');
+    persist(() => deletePersistedTask(taskId), 'Failed to delete task.');
   },
 
   toggleToday: ({ taskId, today }) =>
@@ -315,19 +326,20 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
 
         set({ ...next, errorMsg: '' });
         persist(
-          Promise.all([
-            setCompletion(
-              taskId,
-              date,
-              result.completions.some(
-                (completion) =>
-                  completion.taskId === taskId && completion.date === date,
+          () =>
+            Promise.all([
+              setCompletion(
+                taskId,
+                date,
+                result.completions.some(
+                  (completion) =>
+                    completion.taskId === taskId && completion.date === date,
+                ),
               ),
-            ),
-            ...(result.autoArchived
-              ? [setTaskActive(taskId, false)]
-              : []),
-          ]).then(() => undefined),
+              ...(result.autoArchived
+                ? [setTaskActive(taskId, false)]
+                : []),
+            ]).then(() => undefined),
           'Failed to update completion.',
         );
       } catch (error) {
@@ -353,7 +365,7 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
     };
 
     set({ taskDailyMemos: nextMemos, errorMsg: '' });
-    persist(saveTaskDailyMemo(memo), 'Failed to save memo.');
+    persist(() => saveTaskDailyMemo(memo), 'Failed to save memo.');
   },
 
   startTimer: async ({ taskId, today }) => {
@@ -370,7 +382,10 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
         startedAt: nowIso,
       });
       set({ timeEntries: nextTimeEntries, errorMsg: '' });
-      persist(saveTimeEntries(nextTimeEntries), 'Failed to start timer.');
+      persist(
+        () => saveTimeEntries(nextTimeEntries),
+        'Failed to start timer.',
+      );
     } catch (error) {
       set({ errorMsg: `Failed to start timer. ${formatError(error)}` });
     }
@@ -387,7 +402,10 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
         endedAt: nowIso,
       });
       set({ timeEntries: nextTimeEntries, errorMsg: '' });
-      persist(saveTimeEntries(nextTimeEntries), 'Failed to stop timer.');
+      persist(
+        () => saveTimeEntries(nextTimeEntries),
+        'Failed to stop timer.',
+      );
     } catch (error) {
       set({ errorMsg: `Failed to stop timer. ${formatError(error)}` });
     }
@@ -443,12 +461,7 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
       errorMsg: '',
     });
     persist(
-      Promise.all([
-        saveTimeEntries(result.timeEntries),
-        ...addedCompletions.map((completion) =>
-          setCompletion(completion.taskId, completion.date, true),
-        ),
-      ]).then(() => undefined),
+      () => saveAutoStopTransition(result.timeEntries, addedCompletions),
       'Failed to auto-stop timer.',
     );
 

--- a/apps/desktop/src/infrastructure/storage/index.ts
+++ b/apps/desktop/src/infrastructure/storage/index.ts
@@ -3,7 +3,6 @@ import {
   TaskDailyMemosSchema,
   TasksSchema,
   TimeEntriesSchema,
-  type DayOfWeek,
 } from '../../shared/schemas';
 import type {
   Completion,
@@ -11,27 +10,20 @@ import type {
   TaskDailyMemo,
   TimeEntry,
 } from '../../shared/types';
-import { appDb, type SqlStatement } from '../tauri/db';
+import {
+  appDb,
+  type PersistedAppData,
+} from '../tauri/db';
 import { isTauri } from '../tauri/runtime';
 
 // These keys are persisted data identifiers. Keep them stable unless an
 // explicit data migration accompanies a future rename.
 const STORAGE_KEYS = {
-  // These names are persisted legacy keys. Keep them stable for migration.
   tasks: 'dailycheck.tasks.v2',
   completions: 'dailycheck.completions.v1',
   timeEntries: 'dailycheck.timeEntries.v1',
   taskDailyMemos: 'dailycheck.taskDailyMemos.v1',
 } as const;
-
-const LEGACY_STORAGE_MIGRATION_KEY = 'legacy_storage_migrated_v1';
-
-type PersistedAppData = {
-  tasks: Task[];
-  completions: Completion[];
-  timeEntries: TimeEntry[];
-  taskDailyMemos: TaskDailyMemo[];
-};
 
 type LegacyCollection<T> = {
   value: T;
@@ -42,46 +34,6 @@ type LegacyAppData = {
   data: PersistedAppData;
   valid: boolean;
   hasData: boolean;
-};
-
-type MetaRow = {
-  value: string;
-};
-
-type TaskRow = {
-  id: string;
-  title: string;
-  description: string;
-  category: Task['category'];
-  days_of_week: string;
-  duration_minutes: number;
-  start_ymd: string | null;
-  auto_archive_after: number | null;
-  repeat_count: number | null;
-  is_active: number;
-  created_at: string;
-};
-
-type CompletionRow = {
-  task_id: string;
-  date: string;
-};
-
-type TimeEntryRow = {
-  id: string;
-  task_id: string;
-  date: string;
-  started_at: string;
-  ended_at: string | null;
-  minutes: number;
-};
-
-type TaskDailyMemoRow = {
-  id: string;
-  task_id: string;
-  date: string;
-  text: string;
-  updated_at: string;
 };
 
 function parseLegacyJson<T>(
@@ -106,230 +58,6 @@ function parseLegacyJson<T>(
   } catch {
     return { value: fallback, valid: false };
   }
-}
-
-function parseLegacyDaysOfWeek(value: string): DayOfWeek[] {
-  try {
-    const parsed = JSON.parse(value) as unknown;
-    const result = TasksSchema.element.shape.daysOfWeek.safeParse(parsed);
-    return result.success ? [...result.data] : [];
-  } catch {
-    return [];
-  }
-}
-
-function taskFromRow(row: TaskRow): Task {
-  return {
-    id: row.id,
-    title: row.title,
-    description: row.description,
-    category: row.category,
-    daysOfWeek: parseLegacyDaysOfWeek(row.days_of_week),
-    durationMinutes: Number(row.duration_minutes),
-    startYmd: row.start_ymd,
-    autoArchiveAfter:
-      row.auto_archive_after == null ? null : Number(row.auto_archive_after),
-    repeatCount: row.repeat_count == null ? null : Number(row.repeat_count),
-    isActive: Boolean(row.is_active),
-    createdAt: row.created_at,
-  };
-}
-
-function completionFromRow(row: CompletionRow): Completion {
-  return {
-    taskId: row.task_id,
-    date: row.date,
-  };
-}
-
-function timeEntryFromRow(row: TimeEntryRow): TimeEntry {
-  return {
-    id: row.id,
-    taskId: row.task_id,
-    date: row.date,
-    startedAt: row.started_at,
-    endedAt: row.ended_at,
-    minutes: Number(row.minutes),
-  };
-}
-
-function memoFromRow(row: TaskDailyMemoRow): TaskDailyMemo {
-  return {
-    id: row.id,
-    taskId: row.task_id,
-    date: row.date,
-    text: row.text,
-    updatedAt: row.updated_at,
-  };
-}
-
-async function getMeta(key: string): Promise<string | null> {
-  const rows = await appDb.select<MetaRow>(
-    'SELECT value FROM app_meta WHERE key = ? LIMIT 1',
-    [key],
-  );
-  return rows[0]?.value ?? null;
-}
-
-async function setMeta(key: string, value: string): Promise<void> {
-  await appDb.execute(
-    `
-      INSERT INTO app_meta (key, value)
-      VALUES (?, ?)
-      ON CONFLICT(key) DO UPDATE SET value = excluded.value
-    `,
-    [key, value],
-  );
-}
-
-async function hasExistingData(): Promise<boolean> {
-  const [tasks, completions, timeEntries, memos] = await Promise.all([
-    appDb.select<{ count: number }>('SELECT COUNT(*) AS count FROM tasks'),
-    appDb.select<{ count: number }>(
-      'SELECT COUNT(*) AS count FROM completions',
-    ),
-    appDb.select<{ count: number }>(
-      'SELECT COUNT(*) AS count FROM time_entries',
-    ),
-    appDb.select<{ count: number }>(
-      'SELECT COUNT(*) AS count FROM task_daily_memos',
-    ),
-  ]);
-
-  return [tasks, completions, timeEntries, memos].some(
-    (rows) => Number(rows[0]?.count ?? 0) > 0,
-  );
-}
-
-function statement(sql: string, bind: unknown[] = []): SqlStatement {
-  return { sql, bind };
-}
-
-function buildTaskStatements(tasks: Task[]): SqlStatement[] {
-  return [
-    statement('DELETE FROM tasks'),
-    ...tasks.map((task) =>
-      statement(
-        `
-          INSERT INTO tasks (
-            id,
-            title,
-            description,
-            category,
-            days_of_week,
-            duration_minutes,
-            start_ymd,
-            auto_archive_after,
-            repeat_count,
-            is_active,
-            created_at
-          )
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        `,
-        [
-          task.id,
-          task.title,
-          task.description,
-          task.category,
-          JSON.stringify(task.daysOfWeek),
-          task.durationMinutes,
-          task.startYmd ?? null,
-          task.autoArchiveAfter ?? null,
-          task.repeatCount ?? null,
-          task.isActive ? 1 : 0,
-          task.createdAt,
-        ],
-      ),
-    ),
-  ];
-}
-
-function buildCompletionStatements(
-  completions: Completion[],
-): SqlStatement[] {
-  return [
-    statement('DELETE FROM completions'),
-    ...completions.map((completion) =>
-      statement('INSERT INTO completions (task_id, date) VALUES (?, ?)', [
-        completion.taskId,
-        completion.date,
-      ]),
-    ),
-  ];
-}
-
-function buildTimeEntryStatements(timeEntries: TimeEntry[]): SqlStatement[] {
-  return [
-    statement('DELETE FROM time_entries'),
-    ...timeEntries.map((entry) =>
-      statement(
-        `
-          INSERT INTO time_entries (
-            id,
-            task_id,
-            date,
-            started_at,
-            ended_at,
-            minutes
-          )
-          VALUES (?, ?, ?, ?, ?, ?)
-        `,
-        [
-          entry.id,
-          entry.taskId,
-          entry.date,
-          entry.startedAt,
-          entry.endedAt,
-          entry.minutes,
-        ],
-      ),
-    ),
-  ];
-}
-
-function buildMemoStatements(taskDailyMemos: TaskDailyMemo[]): SqlStatement[] {
-  return [
-    statement('DELETE FROM task_daily_memos'),
-    ...taskDailyMemos.map((memo) =>
-      statement(
-        `
-          INSERT INTO task_daily_memos (
-            id,
-            task_id,
-            date,
-            text,
-            updated_at
-          )
-          VALUES (?, ?, ?, ?, ?)
-        `,
-        [memo.id, memo.taskId, memo.date, memo.text, memo.updatedAt],
-      ),
-    ),
-  ];
-}
-
-function buildSnapshotStatements(data: PersistedAppData): SqlStatement[] {
-  return [
-    ...buildTaskStatements(data.tasks),
-    ...buildCompletionStatements(data.completions),
-    ...buildTimeEntryStatements(data.timeEntries),
-    ...buildMemoStatements(data.taskDailyMemos),
-  ];
-}
-
-let writeQueue: Promise<void> = Promise.resolve();
-
-function enqueueWrite(operation: () => Promise<void>): Promise<void> {
-  const queued = writeQueue.then(operation, operation);
-  writeQueue = queued.catch(() => undefined);
-  return queued;
-}
-
-async function saveAppData(data: PersistedAppData): Promise<void> {
-  if (!isTauri()) return;
-
-  await appDb.init();
-  await appDb.executeTransaction(buildSnapshotStatements(data));
 }
 
 function loadLegacyAppData(): LegacyAppData {
@@ -378,15 +106,10 @@ function clearLegacyAppData(): void {
   }
 }
 
+let migrationPromise: Promise<void> | null = null;
+
 async function migrateLegacyStorageIfNeeded(): Promise<void> {
   if (!isTauri()) return;
-
-  await appDb.init();
-
-  const alreadyMigrated = await getMeta(LEGACY_STORAGE_MIGRATION_KEY);
-  if (alreadyMigrated === '1') {
-    return;
-  }
 
   const legacyData = loadLegacyAppData();
   if (!legacyData.valid) {
@@ -396,18 +119,24 @@ async function migrateLegacyStorageIfNeeded(): Promise<void> {
     return;
   }
 
-  if (await hasExistingData()) {
-    await setMeta(LEGACY_STORAGE_MIGRATION_KEY, '1');
+  const result = await appDb.importLegacy(legacyData.data);
+  // The Rust adapter writes the import marker only after a committed import.
+  // If current SQLite data already exists, it explicitly wins over legacy data.
+  if (result.imported || result.skippedExistingData || !legacyData.hasData) {
     clearLegacyAppData();
-    return;
   }
+}
 
-  if (legacyData.hasData) {
-    await saveAppData(legacyData.data);
+async function ensureLegacyMigration(): Promise<void> {
+  if (!migrationPromise) {
+    migrationPromise = migrateLegacyStorageIfNeeded();
   }
-
-  clearLegacyAppData();
-  await setMeta(LEGACY_STORAGE_MIGRATION_KEY, '1');
+  const pending = migrationPromise;
+  try {
+    await pending;
+  } finally {
+    if (migrationPromise === pending) migrationPromise = null;
+  }
 }
 
 export async function loadAppData(): Promise<PersistedAppData> {
@@ -420,114 +149,61 @@ export async function loadAppData(): Promise<PersistedAppData> {
     };
   }
 
-  await migrateLegacyStorageIfNeeded();
-
-  const [taskRows, completionRows, timeEntryRows, memoRows] = await Promise.all(
-    [
-      appDb.select<TaskRow>(
-        `
-        SELECT
-          id,
-          title,
-          description,
-          category,
-          days_of_week,
-          duration_minutes,
-          start_ymd,
-          auto_archive_after,
-          repeat_count,
-          is_active,
-          created_at
-        FROM tasks
-        ORDER BY created_at DESC
-      `,
-      ),
-      appDb.select<CompletionRow>(
-        'SELECT task_id, date FROM completions ORDER BY date DESC, task_id ASC',
-      ),
-      appDb.select<TimeEntryRow>(
-        `
-        SELECT
-          id,
-          task_id,
-          date,
-          started_at,
-          ended_at,
-          minutes
-        FROM time_entries
-        ORDER BY started_at DESC
-      `,
-      ),
-      appDb.select<TaskDailyMemoRow>(
-        `
-        SELECT
-          id,
-          task_id,
-          date,
-          text,
-          updated_at
-        FROM task_daily_memos
-        ORDER BY updated_at DESC
-      `,
-      ),
-    ],
-  );
+  await appDb.init();
+  await ensureLegacyMigration();
+  const data = await appDb.load();
 
   return {
-    tasks: TasksSchema.parse(taskRows.map(taskFromRow)) as Task[],
-    completions: CompletionsSchema.parse(
-      completionRows.map(completionFromRow),
-    ) as Completion[],
-    timeEntries: TimeEntriesSchema.parse(
-      timeEntryRows.map(timeEntryFromRow),
-    ) as TimeEntry[],
+    tasks: TasksSchema.parse(data.tasks) as Task[],
+    completions: CompletionsSchema.parse(data.completions) as Completion[],
+    timeEntries: TimeEntriesSchema.parse(data.timeEntries) as TimeEntry[],
     taskDailyMemos: TaskDailyMemosSchema.parse(
-      memoRows.map(memoFromRow),
+      data.taskDailyMemos,
     ) as TaskDailyMemo[],
   };
 }
 
-export async function saveTasks(tasks: Task[]): Promise<void> {
-  return enqueueWrite(async () => {
-    await migrateLegacyStorageIfNeeded();
-    const current = await loadAppData();
-    await saveAppData({ ...current, tasks });
-  });
+export async function saveTask(task: Task): Promise<void> {
+  if (!isTauri()) return;
+  await ensureLegacyMigration();
+  await appDb.saveTask(task);
 }
 
-export async function saveCompletions(
-  completions: Completion[],
+export async function setTaskActive(
+  taskId: string,
+  isActive: boolean,
 ): Promise<void> {
-  return enqueueWrite(async () => {
-    await migrateLegacyStorageIfNeeded();
-    const current = await loadAppData();
-    await saveAppData({ ...current, completions });
-  });
+  if (!isTauri()) return;
+  await ensureLegacyMigration();
+  await appDb.setTaskActive(taskId, isActive);
 }
 
-export async function saveTimeEntries(timeEntries: TimeEntry[]): Promise<void> {
-  return enqueueWrite(async () => {
-    await migrateLegacyStorageIfNeeded();
-    const current = await loadAppData();
-    await saveAppData({ ...current, timeEntries });
-  });
+export async function deleteTask(taskId: string): Promise<void> {
+  if (!isTauri()) return;
+  await ensureLegacyMigration();
+  await appDb.deleteTask(taskId);
 }
 
-export async function saveTaskDailyMemos(
-  taskDailyMemos: TaskDailyMemo[],
+export async function setCompletion(
+  taskId: string,
+  date: string,
+  completed: boolean,
 ): Promise<void> {
-  return enqueueWrite(async () => {
-    await migrateLegacyStorageIfNeeded();
-    const current = await loadAppData();
-    await saveAppData({ ...current, taskDailyMemos });
-  });
+  if (!isTauri()) return;
+  await ensureLegacyMigration();
+  await appDb.setCompletion(taskId, date, completed);
 }
 
-export async function replaceAllAppData(data: PersistedAppData): Promise<void> {
-  return enqueueWrite(async () => {
-    await migrateLegacyStorageIfNeeded();
-    await saveAppData(data);
-  });
+export async function saveTimeEntries(entries: TimeEntry[]): Promise<void> {
+  if (!isTauri()) return;
+  await ensureLegacyMigration();
+  await appDb.saveTimeEntries(entries);
+}
+
+export async function saveTaskDailyMemo(memo: TaskDailyMemo): Promise<void> {
+  if (!isTauri()) return;
+  await ensureLegacyMigration();
+  await appDb.saveTaskDailyMemo(memo);
 }
 
 export async function loadTasks(): Promise<Task[]> {

--- a/apps/desktop/src/infrastructure/storage/index.ts
+++ b/apps/desktop/src/infrastructure/storage/index.ts
@@ -200,6 +200,15 @@ export async function saveTimeEntries(entries: TimeEntry[]): Promise<void> {
   await appDb.saveTimeEntries(entries);
 }
 
+export async function saveAutoStopTransition(
+  timeEntries: TimeEntry[],
+  completions: Completion[],
+): Promise<void> {
+  if (!isTauri()) return;
+  await ensureLegacyMigration();
+  await appDb.saveAutoStopTransition(timeEntries, completions);
+}
+
 export async function saveTaskDailyMemo(memo: TaskDailyMemo): Promise<void> {
   if (!isTauri()) return;
   await ensureLegacyMigration();

--- a/apps/desktop/src/infrastructure/tauri/db.ts
+++ b/apps/desktop/src/infrastructure/tauri/db.ts
@@ -73,6 +73,15 @@ async function saveTimeEntries(entries: TimeEntry[]): Promise<void> {
   return invokePersistence<void>('save_time_entries', { entries });
 }
 
+async function saveAutoStopTransition(
+  timeEntries: TimeEntry[],
+  completions: Completion[],
+): Promise<void> {
+  return invokePersistence<void>('save_auto_stop_transition', {
+    request: { timeEntries, completions },
+  });
+}
+
 async function saveTaskDailyMemo(memo: TaskDailyMemo): Promise<void> {
   return invokePersistence<void>('save_task_daily_memo', { memo });
 }
@@ -106,6 +115,7 @@ export const appDb = {
   deleteTask,
   setCompletion,
   saveTimeEntries,
+  saveAutoStopTransition,
   saveTaskDailyMemo,
   getSetting,
   setSetting,

--- a/apps/desktop/src/infrastructure/tauri/db.ts
+++ b/apps/desktop/src/infrastructure/tauri/db.ts
@@ -1,150 +1,114 @@
-import { isTauri } from './runtime';
 import { invoke } from '@tauri-apps/api/core';
+import { isTauri } from './runtime';
+import type {
+  Completion,
+  Task,
+  TaskDailyMemo,
+  TimeEntry,
+} from '../../shared/types';
 
-export type SqlStatement = {
-  sql: string;
-  bind: unknown[];
+export type PersistedAppData = {
+  tasks: Task[];
+  completions: Completion[];
+  timeEntries: TimeEntry[];
+  taskDailyMemos: TaskDailyMemo[];
 };
 
-export type AppDb = {
-  init(): Promise<void>;
-  execute(sql: string, bind?: unknown[]): Promise<void>;
-  select<T>(sql: string, bind?: unknown[]): Promise<T[]>;
-  executeTransaction(statements: SqlStatement[]): Promise<void>;
+type LegacyMigrationOutput = {
+  imported: boolean;
+  skippedExistingData: boolean;
 };
 
-// Keep the existing database filename; changing it would bypass the native migration.
-const DB_URL = 'sqlite:daily_check.db';
-
-let dbPromise: Promise<import('@tauri-apps/plugin-sql').default> | null = null;
-let initPromise: Promise<void> | null = null;
-
-async function getDatabase(): Promise<import('@tauri-apps/plugin-sql').default> {
+async function invokePersistence<T>(
+  command: string,
+  payload?: Record<string, unknown>,
+): Promise<T> {
   if (!isTauri()) {
-    throw new Error('SQLite is unavailable in web runtime.');
+    throw new Error('Desktop persistence is unavailable in web runtime.');
   }
-
-  if (!dbPromise) {
-    dbPromise = import('@tauri-apps/plugin-sql').then(({ default: Database }) =>
-      Database.load(DB_URL),
-    );
-  }
-
-  return dbPromise;
-}
-
-async function initializeSchema(): Promise<void> {
-  const db = await getDatabase();
-  await db.execute(
-    `
-      CREATE TABLE IF NOT EXISTS settings_kv (
-        key TEXT PRIMARY KEY,
-        value TEXT NOT NULL
-      )
-    `,
-    [],
-  );
-  await db.execute(
-    `
-      CREATE TABLE IF NOT EXISTS app_meta (
-        key TEXT PRIMARY KEY,
-        value TEXT NOT NULL
-      )
-    `,
-    [],
-  );
-  await db.execute(
-    `
-      CREATE TABLE IF NOT EXISTS tasks (
-        id TEXT PRIMARY KEY,
-        title TEXT NOT NULL,
-        description TEXT NOT NULL,
-        category TEXT NOT NULL,
-        days_of_week TEXT NOT NULL,
-        duration_minutes INTEGER NOT NULL,
-        start_ymd TEXT,
-        auto_archive_after INTEGER,
-        repeat_count INTEGER,
-        is_active INTEGER NOT NULL,
-        created_at TEXT NOT NULL
-      )
-    `,
-    [],
-  );
-  await db.execute(
-    `
-      CREATE TABLE IF NOT EXISTS completions (
-        task_id TEXT NOT NULL,
-        date TEXT NOT NULL,
-        PRIMARY KEY (task_id, date)
-      )
-    `,
-    [],
-  );
-  await db.execute(
-    `
-      CREATE TABLE IF NOT EXISTS time_entries (
-        id TEXT PRIMARY KEY,
-        task_id TEXT NOT NULL,
-        date TEXT NOT NULL,
-        started_at TEXT NOT NULL,
-        ended_at TEXT,
-        minutes INTEGER NOT NULL
-      )
-    `,
-    [],
-  );
-  await db.execute(
-    `
-      CREATE TABLE IF NOT EXISTS task_daily_memos (
-        id TEXT PRIMARY KEY,
-        task_id TEXT NOT NULL,
-        date TEXT NOT NULL,
-        text TEXT NOT NULL,
-        updated_at TEXT NOT NULL,
-        UNIQUE (task_id, date)
-      )
-    `,
-    [],
-  );
+  return invoke<T>(command, payload);
 }
 
 async function init(): Promise<void> {
-  if (!isTauri()) return;
-
-  if (!initPromise) {
-    initPromise = initializeSchema().catch((error) => {
-      initPromise = null;
-      throw error;
-    });
-  }
-
-  await initPromise;
+  await invokePersistence<void>('initialize_app_database');
 }
 
-async function execute(sql: string, bind: unknown[] = []): Promise<void> {
-  if (!isTauri()) return;
-  const db = await getDatabase();
-  await db.execute(sql, bind);
+async function load(): Promise<PersistedAppData> {
+  return invokePersistence<PersistedAppData>('load_app_data');
 }
 
-async function select<T>(sql: string, bind: unknown[] = []): Promise<T[]> {
-  if (!isTauri()) {
-    return [];
-  }
-  const db = await getDatabase();
-  return db.select<T[]>(sql, bind);
+async function importLegacy(
+  data: PersistedAppData,
+): Promise<LegacyMigrationOutput> {
+  return invokePersistence<LegacyMigrationOutput>('import_legacy_app_data', {
+    data,
+  });
 }
 
-async function executeTransaction(statements: SqlStatement[]): Promise<void> {
-  if (!isTauri()) return;
-
-  await invoke('execute_app_transaction', { statements });
+async function saveTask(task: Task): Promise<void> {
+  return invokePersistence<void>('save_task', { task });
 }
 
-export const appDb: AppDb = {
+async function setTaskActive(taskId: string, isActive: boolean): Promise<void> {
+  return invokePersistence<void>('set_task_active', {
+    request: { taskId, isActive },
+  });
+}
+
+async function deleteTask(taskId: string): Promise<void> {
+  return invokePersistence<void>('delete_task', { taskId });
+}
+
+async function setCompletion(
+  taskId: string,
+  date: string,
+  completed: boolean,
+): Promise<void> {
+  return invokePersistence<void>('set_completion', {
+    request: { taskId, date, completed },
+  });
+}
+
+async function saveTimeEntries(entries: TimeEntry[]): Promise<void> {
+  return invokePersistence<void>('save_time_entries', { entries });
+}
+
+async function saveTaskDailyMemo(memo: TaskDailyMemo): Promise<void> {
+  return invokePersistence<void>('save_task_daily_memo', { memo });
+}
+
+async function getSetting<T>(key: string): Promise<T | null> {
+  return invokePersistence<T | null>('get_setting', { key });
+}
+
+async function setSetting(key: string, value: unknown): Promise<void> {
+  return invokePersistence<void>('set_setting', {
+    request: { key, value },
+  });
+}
+
+async function getMigrationMarker(key: string): Promise<string | null> {
+  return invokePersistence<string | null>('get_migration_marker', { key });
+}
+
+async function setMigrationMarker(key: string, value: string): Promise<void> {
+  return invokePersistence<void>('set_migration_marker', {
+    request: { key, value },
+  });
+}
+
+export const appDb = {
   init,
-  execute,
-  select,
-  executeTransaction,
+  load,
+  importLegacy,
+  saveTask,
+  setTaskActive,
+  deleteTask,
+  setCompletion,
+  saveTimeEntries,
+  saveTaskDailyMemo,
+  getSetting,
+  setSetting,
+  getMigrationMarker,
+  setMigrationMarker,
 };

--- a/apps/desktop/src/infrastructure/tauri/store.ts
+++ b/apps/desktop/src/infrastructure/tauri/store.ts
@@ -5,57 +5,12 @@ const SETTINGS_FILE = 'settings.json';
 const LEGACY_SETTINGS_MIGRATION_KEY = 'legacy_settings_migrated_v1';
 const LEGACY_SETTING_KEYS = ['locale', 'settings.notifications.timerDone'] as const;
 
-type SqlValueRow = {
-  value: string;
-};
-
-type MetaRow = {
-  value: string;
-};
-
-async function getMeta(key: string): Promise<string | null> {
-  const rows = await appDb.select<MetaRow>(
-    'SELECT value FROM app_meta WHERE key = ? LIMIT 1',
-    [key],
-  );
-  return rows[0]?.value ?? null;
-}
-
-async function setMeta(key: string, value: string): Promise<void> {
-  await appDb.execute(
-    `
-      INSERT INTO app_meta (key, value)
-      VALUES (?, ?)
-      ON CONFLICT(key) DO UPDATE SET value = excluded.value
-    `,
-    [key, value],
-  );
-}
-
 async function readSqlSetting<T>(key: string): Promise<T | null> {
-  const rows = await appDb.select<SqlValueRow>(
-    'SELECT value FROM settings_kv WHERE key = ? LIMIT 1',
-    [key],
-  );
-
-  if (!rows[0]) return null;
-
-  try {
-    return JSON.parse(rows[0].value) as T;
-  } catch {
-    return null;
-  }
+  return appDb.getSetting<T>(key);
 }
 
 async function writeSqlSetting(key: string, value: unknown): Promise<void> {
-  await appDb.execute(
-    `
-      INSERT INTO settings_kv (key, value)
-      VALUES (?, ?)
-      ON CONFLICT(key) DO UPDATE SET value = excluded.value
-    `,
-    [key, JSON.stringify(value)],
-  );
+  await appDb.setSetting(key, value);
 }
 
 type LegacySetting = {
@@ -77,12 +32,10 @@ function readLegacyStorageSetting(key: string): LegacySetting {
 async function migrateLegacySettingsIfNeeded(): Promise<void> {
   if (!isTauri()) return;
 
-  await appDb.init();
-
-  const alreadyMigrated = await getMeta(LEGACY_SETTINGS_MIGRATION_KEY);
-  if (alreadyMigrated === '1') {
-    return;
-  }
+  const alreadyMigrated = await appDb.getMigrationMarker(
+    LEGACY_SETTINGS_MIGRATION_KEY,
+  );
+  if (alreadyMigrated === '1') return;
 
   let legacyStoreValues = new Map<string, unknown>();
   let hasInvalidLegacyValue = false;
@@ -123,7 +76,7 @@ async function migrateLegacySettingsIfNeeded(): Promise<void> {
   }
 
   if (!hasInvalidLegacyValue) {
-    await setMeta(LEGACY_SETTINGS_MIGRATION_KEY, '1');
+    await appDb.setMigrationMarker(LEGACY_SETTINGS_MIGRATION_KEY, '1');
   }
 }
 

--- a/apps/desktop/tests/persistence-boundary.test.ts
+++ b/apps/desktop/tests/persistence-boundary.test.ts
@@ -46,6 +46,7 @@ describe('Tauri persistence boundary', () => {
     });
     await appDb.setCompletion('task-1', '2026-01-05', true);
     await appDb.saveTimeEntries([]);
+    await appDb.saveAutoStopTransition([], []);
     await appDb.saveTaskDailyMemo({
       id: 'task-1_2026-01-05',
       taskId: 'task-1',
@@ -60,6 +61,7 @@ describe('Tauri persistence boundary', () => {
       'save_task',
       'set_completion',
       'save_time_entries',
+      'save_auto_stop_transition',
       'save_task_daily_memo',
     ]);
     expect(calls.some((call) => call.command.includes('sql'))).toBe(false);

--- a/apps/desktop/tests/persistence-boundary.test.ts
+++ b/apps/desktop/tests/persistence-boundary.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const calls: Array<{ command: string; payload: unknown }> = [];
+
+mock.module('@tauri-apps/api/core', () => ({
+  invoke: async (command: string, payload?: unknown) => {
+    calls.push({ command, payload });
+    return command === 'load_app_data'
+      ? {
+          tasks: [],
+          completions: [],
+          timeEntries: [],
+          taskDailyMemos: [],
+        }
+      : command === 'get_setting' || command === 'get_migration_marker'
+        ? null
+        : undefined;
+  },
+}));
+
+Object.assign(globalThis, {
+  window: {},
+  __TAURI_INTERNALS__: {},
+});
+
+const { appDb } = await import('../src/infrastructure/tauri/db.ts');
+
+describe('Tauri persistence boundary', () => {
+  beforeEach(() => calls.splice(0));
+
+  test('exposes typed domain operations instead of SQL execution', async () => {
+    await appDb.init();
+    await appDb.load();
+    await appDb.saveTask({
+      id: 'task-1',
+      title: 'Focus',
+      description: '',
+      category: 'daily',
+      daysOfWeek: ['Mon'],
+      durationMinutes: 30,
+      startYmd: null,
+      autoArchiveAfter: null,
+      repeatCount: null,
+      isActive: true,
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    await appDb.setCompletion('task-1', '2026-01-05', true);
+    await appDb.saveTimeEntries([]);
+    await appDb.saveTaskDailyMemo({
+      id: 'task-1_2026-01-05',
+      taskId: 'task-1',
+      date: '2026-01-05',
+      text: 'Note',
+      updatedAt: '2026-01-05T10:00:00.000Z',
+    });
+
+    expect(calls.map((call) => call.command)).toEqual([
+      'initialize_app_database',
+      'load_app_data',
+      'save_task',
+      'set_completion',
+      'save_time_entries',
+      'save_task_daily_memo',
+    ]);
+    expect(calls.some((call) => call.command.includes('sql'))).toBe(false);
+  });
+});

--- a/apps/desktop/tests/persistence.test.ts
+++ b/apps/desktop/tests/persistence.test.ts
@@ -1,67 +1,83 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 
-type FakeStorage = {
-  getItem(key: string): string | null;
-  removeItem(key: string): void;
-  setItem(key: string, value: string): void;
+type PersistedAppData = {
+  tasks: typeof validLegacyTask[];
+  completions: Array<{ taskId: string; date: string }>;
+  timeEntries: Array<{
+    id: string;
+    taskId: string;
+    date: string;
+    startedAt: string;
+    endedAt: string | null;
+    minutes: number;
+  }>;
+  taskDailyMemos: Array<{
+    id: string;
+    taskId: string;
+    date: string;
+    text: string;
+    updatedAt: string;
+  }>;
 };
 
 const storageValues = new Map<string, string>();
-const executedSql: string[] = [];
-const transactions: string[][] = [];
-let migrationMarker = '0';
-let failWrites = false;
-let openTransactions = 0;
-let maxOpenTransactions = 0;
-let committedTransactions = 0;
-let rolledBackTransactions = 0;
+let databaseData: PersistedAppData = {
+  tasks: [],
+  completions: [],
+  timeEntries: [],
+  taskDailyMemos: [],
+};
+let migrationMarker = false;
+let importCalls = 0;
+let saveTaskCalls = 0;
 
-const fakeStorage: FakeStorage = {
-  getItem: (key) => storageValues.get(key) ?? null,
-  removeItem: (key) => storageValues.delete(key),
-  setItem: (key, value) => storageValues.set(key, value),
+const fakeStorage = {
+  getItem: (key: string) => storageValues.get(key) ?? null,
+  removeItem: (key: string) => storageValues.delete(key),
+  setItem: (key: string, value: string) => storageValues.set(key, value),
 };
 
 const fakeAppDb = {
   init: async () => undefined,
-  execute: async (sql: string) => {
-    executedSql.push(sql.trim());
-    if (sql.includes('INSERT INTO app_meta')) migrationMarker = '1';
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  },
-  executeTransaction: async (
-    statements: Array<{ sql: string; bind: unknown[] }>,
-  ) => {
-    const sqlStatements = statements.map(({ sql }) => sql.trim());
-    transactions.push(sqlStatements);
-    openTransactions += 1;
-    maxOpenTransactions = Math.max(maxOpenTransactions, openTransactions);
+  load: async () => databaseData,
+  importLegacy: async (data: PersistedAppData) => {
+    importCalls += 1;
+    if (migrationMarker) {
+      return { imported: false, skippedExistingData: false };
+    }
 
-    try {
-      for (const sql of sqlStatements) {
-        executedSql.push(sql);
-        if (failWrites && sql.includes('INSERT INTO tasks')) {
-          throw new Error('simulated write failure');
-        }
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      }
-      committedTransactions += 1;
-    } catch (error) {
-      rolledBackTransactions += 1;
-      throw error;
-    } finally {
-      openTransactions -= 1;
+    const hasExistingData = Object.values(databaseData).some(
+      (collection) => collection.length > 0,
+    );
+    if (hasExistingData) {
+      migrationMarker = true;
+      return { imported: false, skippedExistingData: true };
     }
+
+    databaseData = data;
+    migrationMarker = true;
+    return {
+      imported: Object.values(data).some((collection) => collection.length > 0),
+      skippedExistingData: false,
+    };
   },
-  select: async <T>(sql: string): Promise<T[]> => {
-    if (sql.includes('SELECT value FROM app_meta')) {
-      return migrationMarker === '1'
-        ? ([{ value: '1' }] as T[])
-        : ([] as T[]);
-    }
-    if (sql.includes('COUNT(*)')) return [{ count: 0 }] as T[];
-    return [] as T[];
+  saveTask: async (task: (typeof validLegacyTask) & { id: string }) => {
+    saveTaskCalls += 1;
+    databaseData = {
+      ...databaseData,
+      tasks: [
+        task,
+        ...databaseData.tasks.filter((candidate) => candidate.id !== task.id),
+      ],
+    };
   },
+  setTaskActive: async () => undefined,
+  deleteTask: async () => undefined,
+  setCompletion: async () => undefined,
+  saveTimeEntries: async () => undefined,
+  saveTaskDailyMemo: async () => undefined,
+  getSetting: async () => null,
+  setSetting: async () => undefined,
 };
 
 mock.module('../src/infrastructure/tauri/db.ts', () => ({
@@ -74,16 +90,17 @@ Object.assign(globalThis, {
   localStorage: fakeStorage,
 });
 
-const { loadAppData, replaceAllAppData } = await import(
-  '../src/infrastructure/storage/index.ts'
-);
+const {
+  loadAppData,
+  saveTask,
+} = await import('../src/infrastructure/storage/index.ts');
 
 const validLegacyTask = {
   id: 'task-legacy',
   title: 'Migrated task',
   description: '',
-  category: 'weekday',
-  daysOfWeek: ['Mon'],
+  category: 'weekday' as const,
+  daysOfWeek: ['Mon'] as const,
   durationMinutes: 30,
   startYmd: null,
   autoArchiveAfter: null,
@@ -92,17 +109,18 @@ const validLegacyTask = {
   createdAt: '2026-01-01T00:00:00.000Z',
 };
 
-describe('SQLite persistence safety', () => {
+describe('typed desktop persistence adapter', () => {
   beforeEach(() => {
     storageValues.clear();
-    executedSql.length = 0;
-    transactions.length = 0;
-    migrationMarker = '0';
-    failWrites = false;
-    openTransactions = 0;
-    maxOpenTransactions = 0;
-    committedTransactions = 0;
-    rolledBackTransactions = 0;
+    databaseData = {
+      tasks: [],
+      completions: [],
+      timeEntries: [],
+      taskDailyMemos: [],
+    };
+    migrationMarker = false;
+    importCalls = 0;
+    saveTaskCalls = 0;
   });
 
   test('migrates valid legacy data before removing legacy keys', async () => {
@@ -113,17 +131,11 @@ describe('SQLite persistence safety', () => {
 
     const data = await loadAppData();
 
-    expect(data.tasks).toEqual([]);
+    expect(data.tasks).toEqual([validLegacyTask]);
     expect(storageValues.has('dailycheck.tasks.v2')).toBe(false);
-    expect(transactions).toHaveLength(1);
-    expect(transactions[0]).toContain('DELETE FROM tasks');
-    expect(transactions[0].some((sql) => sql.includes('INSERT INTO tasks'))).toBe(
-      true,
-    );
-
-    const callsAfterFirstLoad = executedSql.length;
-    await loadAppData();
-    expect(executedSql.length).toBe(callsAfterFirstLoad);
+    expect(importCalls).toBe(1);
+    expect(migrationMarker).toBe(true);
+    expect(databaseData.tasks).toEqual([validLegacyTask]);
   });
 
   test('leaves corrupted legacy input untouched for recovery', async () => {
@@ -132,61 +144,27 @@ describe('SQLite persistence safety', () => {
     await loadAppData();
 
     expect(storageValues.get('dailycheck.tasks.v2')).toBe('{not valid json');
-    expect(executedSql).not.toContain('DELETE FROM tasks');
+    expect(importCalls).toBe(0);
   });
 
-  test('wraps a complete snapshot in one transaction', async () => {
-    await replaceAllAppData({
-      tasks: [],
-      completions: [],
-      timeEntries: [],
-      taskDailyMemos: [],
-    });
+  test('does not replace existing database data with legacy data', async () => {
+    databaseData.tasks = [validLegacyTask];
+    storageValues.set(
+      'dailycheck.tasks.v2',
+      JSON.stringify([{ ...validLegacyTask, id: 'legacy-task' }]),
+    );
 
-    expect(transactions).toEqual([
-      [
-        'DELETE FROM tasks',
-        'DELETE FROM completions',
-        'DELETE FROM time_entries',
-        'DELETE FROM task_daily_memos',
-      ],
-    ]);
-    expect(committedTransactions).toBe(1);
+    const data = await loadAppData();
+
+    expect(data.tasks).toEqual([validLegacyTask]);
+    expect(storageValues.has('dailycheck.tasks.v2')).toBe(false);
+    expect(importCalls).toBe(1);
   });
 
-  test('rolls back when a snapshot write fails', async () => {
-    failWrites = true;
+  test('uses a typed task command for normal writes', async () => {
+    await saveTask(validLegacyTask);
 
-    await expect(
-      replaceAllAppData({
-        tasks: [validLegacyTask],
-        completions: [],
-        timeEntries: [],
-        taskDailyMemos: [],
-      }),
-    ).rejects.toThrow('simulated write failure');
-
-    expect(transactions).toHaveLength(1);
-    expect(rolledBackTransactions).toBe(1);
-    expect(committedTransactions).toBe(0);
-  });
-
-  test('serializes concurrent snapshot saves', async () => {
-    await Promise.all([
-      replaceAllAppData({
-        tasks: [],
-        completions: [],
-        timeEntries: [],
-        taskDailyMemos: [],
-      }),
-      replaceAllAppData({
-        tasks: [],
-        completions: [],
-        timeEntries: [],
-        taskDailyMemos: [],
-      }),
-    ]);
-
-    expect(maxOpenTransactions).toBe(1);
+    expect(saveTaskCalls).toBe(1);
+    expect(databaseData.tasks).toEqual([validLegacyTask]);
   });
 });

--- a/apps/desktop/tests/persistence.test.ts
+++ b/apps/desktop/tests/persistence.test.ts
@@ -37,52 +37,61 @@ const fakeStorage = {
   setItem: (key: string, value: string) => storageValues.set(key, value),
 };
 
-const fakeAppDb = {
-  init: async () => undefined,
-  load: async () => databaseData,
-  importLegacy: async (data: PersistedAppData) => {
-    importCalls += 1;
-    if (migrationMarker) {
-      return { imported: false, skippedExistingData: false };
+mock.module('@tauri-apps/api/core', () => ({
+  invoke: async (
+    command: string,
+    payload?: {
+      data?: PersistedAppData;
+      task?: (typeof validLegacyTask) & { id: string };
+    },
+  ) => {
+    switch (command) {
+      case 'initialize_app_database':
+        return undefined;
+      case 'load_app_data':
+        return databaseData;
+      case 'import_legacy_app_data': {
+        importCalls += 1;
+        if (migrationMarker) {
+          return { imported: false, skippedExistingData: false };
+        }
+
+        const hasExistingData = Object.values(databaseData).some(
+          (collection) => collection.length > 0,
+        );
+        if (hasExistingData) {
+          migrationMarker = true;
+          return { imported: false, skippedExistingData: true };
+        }
+
+        databaseData = payload?.data ?? databaseData;
+        migrationMarker = true;
+        return {
+          imported: Object.values(databaseData).some(
+            (collection) => collection.length > 0,
+          ),
+          skippedExistingData: false,
+        };
+      }
+      case 'save_task': {
+        const task = payload?.task;
+        if (!task) return undefined;
+        saveTaskCalls += 1;
+        databaseData = {
+          ...databaseData,
+          tasks: [
+            task,
+            ...databaseData.tasks.filter(
+              (candidate) => candidate.id !== task.id,
+            ),
+          ],
+        };
+        return undefined;
+      }
+      default:
+        return undefined;
     }
-
-    const hasExistingData = Object.values(databaseData).some(
-      (collection) => collection.length > 0,
-    );
-    if (hasExistingData) {
-      migrationMarker = true;
-      return { imported: false, skippedExistingData: true };
-    }
-
-    databaseData = data;
-    migrationMarker = true;
-    return {
-      imported: Object.values(data).some((collection) => collection.length > 0),
-      skippedExistingData: false,
-    };
   },
-  saveTask: async (task: (typeof validLegacyTask) & { id: string }) => {
-    saveTaskCalls += 1;
-    databaseData = {
-      ...databaseData,
-      tasks: [
-        task,
-        ...databaseData.tasks.filter((candidate) => candidate.id !== task.id),
-      ],
-    };
-  },
-  setTaskActive: async () => undefined,
-  deleteTask: async () => undefined,
-  setCompletion: async () => undefined,
-  saveTimeEntries: async () => undefined,
-  saveAutoStopTransition: async () => undefined,
-  saveTaskDailyMemo: async () => undefined,
-  getSetting: async () => null,
-  setSetting: async () => undefined,
-};
-
-mock.module('../src/infrastructure/tauri/db.ts', () => ({
-  appDb: fakeAppDb,
 }));
 
 Object.assign(globalThis, {

--- a/apps/desktop/tests/persistence.test.ts
+++ b/apps/desktop/tests/persistence.test.ts
@@ -75,6 +75,7 @@ const fakeAppDb = {
   deleteTask: async () => undefined,
   setCompletion: async () => undefined,
   saveTimeEntries: async () => undefined,
+  saveAutoStopTransition: async () => undefined,
   saveTaskDailyMemo: async () => undefined,
   getSetting: async () => null,
   setSetting: async () => undefined,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -47,8 +47,16 @@ persistence. Desktop v0.1 does **not** require a local Axum HTTP server.
 The desktop Tauri adapter now translates the persisted `Task`, `Completion`,
 and `TimeEntry` shapes into core inputs for schedule visibility, completion
 transitions, session transitions, timer auto-stop, and statistics. SQLite
-storage remains an adapter concern; the React layer does not duplicate those
-rules.
+schema, queries, typed writes, and legacy-data import live in the Rust-side
+desktop persistence adapter. React only calls typed Tauri persistence commands
+and never constructs application SQL or owns a full-table replacement.
+
+The existing localStorage collections (`dailycheck.tasks.v2`,
+`dailycheck.completions.v1`, `dailycheck.timeEntries.v1`, and
+`dailycheck.taskDailyMemos.v1`) are imported once into the existing
+`daily_check.db` file. The import is transactional and idempotent: corrupted
+legacy JSON is left in place for recovery, an existing SQLite dataset wins,
+and legacy keys are cleared only after the Rust adapter commits the migration.
 
 The stable Routine/Plan/Session/Completion vocabulary and the compatibility
 mapping for the current desktop records are defined in

--- a/docs/DOMAIN_MODEL.md
+++ b/docs/DOMAIN_MODEL.md
@@ -74,9 +74,10 @@ or the `daily_check.db` filename.
 | `Completion.taskId`, `date` | `Completion::for_routine(RoutineId, LocalDate)` |
 | `TaskDailyMemo.taskId`, `date`, `text`, `updatedAt` | Adapter-owned daily memo record associated with a `Routine` and date |
 
-The current desktop adapter remains responsible for reading/writing these
-legacy collections. Moving the rules into core does not require a destructive
-database migration.
+The desktop persistence adapter remains responsible for reading/writing these
+legacy-shaped records. The React compatibility boundary only reads the old
+localStorage collections during the one-time import; moving the rules into
+core does not require a destructive database migration.
 
 ## Migration baseline
 


### PR DESCRIPTION
Closes #9

## Summary
- Move desktop SQLite schema, queries, typed CRUD, and legacy import into the Rust persistence adapter.
- Replace React-side SQL and full-snapshot writes with typed Tauri commands.
- Preserve the existing daily_check.db filename, localStorage keys, app_meta markers, and local data through transactional, idempotent import.
- Add Rust and frontend persistence-boundary tests and update architecture documentation.

## Validation
- cargo fmt --all -- --check
- cargo test --workspace
- bun test
- bun run lint
- bun run build