### PR TITLE
[Validation] Validate v0.1 foundation, boundaries, and migration

### DIFF
--- a/apps/desktop/bun.lock
+++ b/apps/desktop/bun.lock
@@ -6,8 +6,8 @@
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@tailwindcss/vite": "^4.2.1",
-        "@tauri-apps/api": "^2.10.1",
-        "@tauri-apps/plugin-notification": "^2.3.3",
+        "@tauri-apps/api": "^2.11.1",
+        "@tauri-apps/plugin-notification": "^2.4.0",
         "@tauri-apps/plugin-store": "^2.4.2",
         "clsx": "^2.1.1",
         "lucide-react": "^0.575.0",
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
-        "@tauri-apps/cli": "^2.10.0",
+        "@tauri-apps/cli": "^2.11.4",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
@@ -250,33 +250,33 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.2.1", "", { "dependencies": { "@tailwindcss/node": "4.2.1", "@tailwindcss/oxide": "4.2.1", "tailwindcss": "4.2.1" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7" } }, "sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w=="],
 
-    "@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
+    "@tauri-apps/api": ["@tauri-apps/api@2.11.1", "", {}, "sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA=="],
 
-    "@tauri-apps/cli": ["@tauri-apps/cli@2.10.1", "", { "optionalDependencies": { "@tauri-apps/cli-darwin-arm64": "2.10.1", "@tauri-apps/cli-darwin-x64": "2.10.1", "@tauri-apps/cli-linux-arm-gnueabihf": "2.10.1", "@tauri-apps/cli-linux-arm64-gnu": "2.10.1", "@tauri-apps/cli-linux-arm64-musl": "2.10.1", "@tauri-apps/cli-linux-riscv64-gnu": "2.10.1", "@tauri-apps/cli-linux-x64-gnu": "2.10.1", "@tauri-apps/cli-linux-x64-musl": "2.10.1", "@tauri-apps/cli-win32-arm64-msvc": "2.10.1", "@tauri-apps/cli-win32-ia32-msvc": "2.10.1", "@tauri-apps/cli-win32-x64-msvc": "2.10.1" }, "bin": { "tauri": "tauri.js" } }, "sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g=="],
+    "@tauri-apps/cli": ["@tauri-apps/cli@2.11.4", "", { "optionalDependencies": { "@tauri-apps/cli-darwin-arm64": "2.11.4", "@tauri-apps/cli-darwin-x64": "2.11.4", "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.4", "@tauri-apps/cli-linux-arm64-gnu": "2.11.4", "@tauri-apps/cli-linux-arm64-musl": "2.11.4", "@tauri-apps/cli-linux-riscv64-gnu": "2.11.4", "@tauri-apps/cli-linux-x64-gnu": "2.11.4", "@tauri-apps/cli-linux-x64-musl": "2.11.4", "@tauri-apps/cli-win32-arm64-msvc": "2.11.4", "@tauri-apps/cli-win32-ia32-msvc": "2.11.4", "@tauri-apps/cli-win32-x64-msvc": "2.11.4" }, "bin": { "tauri": "tauri.js" } }, "sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ=="],
 
-    "@tauri-apps/cli-darwin-arm64": ["@tauri-apps/cli-darwin-arm64@2.10.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Z2OjCXiZ+fbYZy7PmP3WRnOpM9+Fy+oonKDEmUE6MwN4IGaYqgceTjwHucc/kEEYZos5GICve35f7ZiizgqEnQ=="],
+    "@tauri-apps/cli-darwin-arm64": ["@tauri-apps/cli-darwin-arm64@2.11.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-1ryOF3ZhpZ/nemHV5zVwBQBz9jDGKmKPvWPADOhc83ig0P4bMc2iER4NbC6r9sjeIZ6RVQ4g3RZIYvezhcl4TQ=="],
 
-    "@tauri-apps/cli-darwin-x64": ["@tauri-apps/cli-darwin-x64@2.10.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-V/irQVvjPMGOTQqNj55PnQPVuH4VJP8vZCN7ajnj+ZS8Kom1tEM2hR3qbbIRoS3dBKs5mbG8yg1WC+97dq17Pw=="],
+    "@tauri-apps/cli-darwin-x64": ["@tauri-apps/cli-darwin-x64@2.11.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-uFsGQAAfuyz1k/yGLmkWfkBlgKAqZfxqlHmLWx81QU27RJWfmbNHCIq8T8w1e+VClleIuZUjpHWfoE4E3DLo3A=="],
 
-    "@tauri-apps/cli-linux-arm-gnueabihf": ["@tauri-apps/cli-linux-arm-gnueabihf@2.10.1", "", { "os": "linux", "cpu": "arm" }, "sha512-Hyzwsb4VnCWKGfTw+wSt15Z2pLw2f0JdFBfq2vHBOBhvg7oi6uhKiF87hmbXOBXUZaGkyRDkCHsdzJcIfoJC2w=="],
+    "@tauri-apps/cli-linux-arm-gnueabihf": ["@tauri-apps/cli-linux-arm-gnueabihf@2.11.4", "", { "os": "linux", "cpu": "arm" }, "sha512-IaHZn5CdBL21oUmjiVOS1ctw6Ip1O0pjp70FwOWmYz1myWe0SY96ZIj2FYf7pT0m8bI2h/hrs5ZbEXXh44/MkQ=="],
 
-    "@tauri-apps/cli-linux-arm64-gnu": ["@tauri-apps/cli-linux-arm64-gnu@2.10.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-OyOYs2t5GkBIvyWjA1+h4CZxTcdz1OZPCWAPz5DYEfB0cnWHERTnQ/SLayQzncrT0kwRoSfSz9KxenkyJoTelA=="],
+    "@tauri-apps/cli-linux-arm64-gnu": ["@tauri-apps/cli-linux-arm64-gnu@2.11.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-N41/ukTRVe6XSuUTESuFdGeOW2i7k62tK+6gHK5Kd5/q5RPvvi19GaWAVPPb9u95HSGmTChSolBfzynUsssFaA=="],
 
-    "@tauri-apps/cli-linux-arm64-musl": ["@tauri-apps/cli-linux-arm64-musl@2.10.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg=="],
+    "@tauri-apps/cli-linux-arm64-musl": ["@tauri-apps/cli-linux-arm64-musl@2.11.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw=="],
 
-    "@tauri-apps/cli-linux-riscv64-gnu": ["@tauri-apps/cli-linux-riscv64-gnu@2.10.1", "", { "os": "linux", "cpu": "none" }, "sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw=="],
+    "@tauri-apps/cli-linux-riscv64-gnu": ["@tauri-apps/cli-linux-riscv64-gnu@2.11.4", "", { "os": "linux", "cpu": "none" }, "sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ=="],
 
-    "@tauri-apps/cli-linux-x64-gnu": ["@tauri-apps/cli-linux-x64-gnu@2.10.1", "", { "os": "linux", "cpu": "x64" }, "sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw=="],
+    "@tauri-apps/cli-linux-x64-gnu": ["@tauri-apps/cli-linux-x64-gnu@2.11.4", "", { "os": "linux", "cpu": "x64" }, "sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ=="],
 
-    "@tauri-apps/cli-linux-x64-musl": ["@tauri-apps/cli-linux-x64-musl@2.10.1", "", { "os": "linux", "cpu": "x64" }, "sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ=="],
+    "@tauri-apps/cli-linux-x64-musl": ["@tauri-apps/cli-linux-x64-musl@2.11.4", "", { "os": "linux", "cpu": "x64" }, "sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A=="],
 
-    "@tauri-apps/cli-win32-arm64-msvc": ["@tauri-apps/cli-win32-arm64-msvc@2.10.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg=="],
+    "@tauri-apps/cli-win32-arm64-msvc": ["@tauri-apps/cli-win32-arm64-msvc@2.11.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ=="],
 
-    "@tauri-apps/cli-win32-ia32-msvc": ["@tauri-apps/cli-win32-ia32-msvc@2.10.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-gXyxgEzsFegmnWywYU5pEBURkcFN/Oo45EAwvZrHMh+zUSEAvO5E8TXsgPADYm31d1u7OQU3O3HsYfVBf2moHw=="],
+    "@tauri-apps/cli-win32-ia32-msvc": ["@tauri-apps/cli-win32-ia32-msvc@2.11.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-12Hxi0XX/H5VFxO/bGgHkFWhml9VMgEOu9CidjeCeTNQ1l6fpUlbiGgSP7CLI3PFtW9/FfbeHieZ+kyWK5H7CA=="],
 
-    "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.10.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6Cn7YpPFwzChy0ERz6djKEmUehWrYlM+xTaNzGPgZocw3BD7OfwfWHKVWxXzdjEW2KfKkHddfdxK1XXTYqBRLg=="],
+    "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.11.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+vDiqBIU5dMISg/wNvX3sF+ZHfgJGJ5T0AcO+EHNXV9GGAG+P5fzodlDXD3QdKCRgZxMoCm5PPvj3BqLNjBthw=="],
 
-    "@tauri-apps/plugin-notification": ["@tauri-apps/plugin-notification@2.3.3", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg=="],
+    "@tauri-apps/plugin-notification": ["@tauri-apps/plugin-notification@2.4.0", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-xlJXMcUoKOjNupzDue5wrEsa1wytf+l/2gCAPhafHyP683Y3N7J/8clUWLZ3vpnwkpT2C1zcLMMQFjjecIG2xg=="],
 
     "@tauri-apps/plugin-store": ["@tauri-apps/plugin-store@2.4.2", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-0ClHS50Oq9HEvLPhNzTNFxbWVOqoAp3dRvtewQBeqfIQ0z5m3JRnOISIn2ZVPCrQC0MyGyhTS9DWhHjpigQE7A=="],
 
@@ -608,6 +608,8 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@tauri-apps/plugin-store/@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
+
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
@@ -616,8 +618,36 @@
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/runtime/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
   }
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -16,8 +16,8 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@tailwindcss/vite": "^4.2.1",
-    "@tauri-apps/api": "^2.10.1",
-    "@tauri-apps/plugin-notification": "^2.3.3",
+    "@tauri-apps/api": "^2.11.1",
+    "@tauri-apps/plugin-notification": "^2.4.0",
     "@tauri-apps/plugin-store": "^2.4.2",
     "clsx": "^2.1.1",
     "lucide-react": "^0.575.0",
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
-    "@tauri-apps/cli": "^2.10.0",
+    "@tauri-apps/cli": "^2.11.4",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",

--- a/apps/desktop/src-tauri/src/persistence.rs
+++ b/apps/desktop/src-tauri/src/persistence.rs
@@ -870,6 +870,141 @@ mod tests {
         }
     }
 
+    fn representative_legacy_data() -> AppData {
+        AppData {
+            tasks: vec![
+                TaskRecord {
+                    id: "active-weekday".to_owned(),
+                    title: "English study".to_owned(),
+                    description: "Review vocabulary".to_owned(),
+                    category: "weekday".to_owned(),
+                    days_of_week: vec![
+                        "Mon".to_owned(),
+                        "Tue".to_owned(),
+                        "Wed".to_owned(),
+                        "Thu".to_owned(),
+                        "Fri".to_owned(),
+                    ],
+                    duration_minutes: 45,
+                    start_ymd: Some("2026-01-05".to_owned()),
+                    auto_archive_after: Some(3),
+                    repeat_count: Some(5),
+                    is_active: true,
+                    created_at: "2026-01-01T08:00:00.000Z".to_owned(),
+                },
+                TaskRecord {
+                    id: "archived-weekend".to_owned(),
+                    title: "Weekend planning".to_owned(),
+                    description: "Historical routine".to_owned(),
+                    category: "weekend".to_owned(),
+                    days_of_week: vec!["Sat".to_owned(), "Sun".to_owned()],
+                    duration_minutes: 20,
+                    start_ymd: None,
+                    auto_archive_after: Some(2),
+                    repeat_count: None,
+                    is_active: false,
+                    created_at: "2025-12-01T08:00:00.000Z".to_owned(),
+                },
+                TaskRecord {
+                    id: "active-custom".to_owned(),
+                    title: "Project writing".to_owned(),
+                    description: "Draft the next section".to_owned(),
+                    category: "custom".to_owned(),
+                    days_of_week: vec!["Tue".to_owned(), "Thu".to_owned()],
+                    duration_minutes: 60,
+                    start_ymd: Some("2026-01-06".to_owned()),
+                    auto_archive_after: Some(4),
+                    repeat_count: None,
+                    is_active: true,
+                    created_at: "2026-01-02T08:00:00.000Z".to_owned(),
+                },
+            ],
+            completions: vec![
+                CompletionRecord {
+                    task_id: "active-weekday".to_owned(),
+                    date: "2026-01-05".to_owned(),
+                },
+                CompletionRecord {
+                    task_id: "active-weekday".to_owned(),
+                    date: "2026-01-12".to_owned(),
+                },
+                CompletionRecord {
+                    task_id: "archived-weekend".to_owned(),
+                    date: "2025-12-20".to_owned(),
+                },
+                CompletionRecord {
+                    task_id: "active-custom".to_owned(),
+                    date: "2026-01-06".to_owned(),
+                },
+            ],
+            time_entries: vec![
+                TimeEntryRecord {
+                    id: "entry-active-history".to_owned(),
+                    task_id: "active-weekday".to_owned(),
+                    date: "2025-12-29".to_owned(),
+                    started_at: "2025-12-29T09:00:00.000Z".to_owned(),
+                    ended_at: Some("2025-12-29T09:40:00.000Z".to_owned()),
+                    minutes: 40,
+                },
+                TimeEntryRecord {
+                    id: "entry-active-running".to_owned(),
+                    task_id: "active-weekday".to_owned(),
+                    date: "2026-01-05".to_owned(),
+                    started_at: "2026-01-05T10:00:00.000Z".to_owned(),
+                    ended_at: None,
+                    minutes: 0,
+                },
+                TimeEntryRecord {
+                    id: "entry-archived-history".to_owned(),
+                    task_id: "archived-weekend".to_owned(),
+                    date: "2025-12-20".to_owned(),
+                    started_at: "2025-12-20T11:00:00.000Z".to_owned(),
+                    ended_at: Some("2025-12-20T11:25:00.000Z".to_owned()),
+                    minutes: 25,
+                },
+                TimeEntryRecord {
+                    id: "entry-custom".to_owned(),
+                    task_id: "active-custom".to_owned(),
+                    date: "2026-01-06".to_owned(),
+                    started_at: "2026-01-06T14:00:00.000Z".to_owned(),
+                    ended_at: Some("2026-01-06T15:10:00.000Z".to_owned()),
+                    minutes: 70,
+                },
+            ],
+            task_daily_memos: vec![
+                TaskDailyMemoRecord {
+                    id: "active-weekday_2025-12-29".to_owned(),
+                    task_id: "active-weekday".to_owned(),
+                    date: "2025-12-29".to_owned(),
+                    text: "Historical note".to_owned(),
+                    updated_at: "2025-12-29T10:00:00.000Z".to_owned(),
+                },
+                TaskDailyMemoRecord {
+                    id: "active-custom_2026-01-06".to_owned(),
+                    task_id: "active-custom".to_owned(),
+                    date: "2026-01-06".to_owned(),
+                    text: "Draft is progressing".to_owned(),
+                    updated_at: "2026-01-06T15:15:00.000Z".to_owned(),
+                },
+            ],
+        }
+    }
+
+    fn normalize_loaded_order(data: &mut AppData) {
+        data.tasks
+            .sort_by(|left, right| right.created_at.cmp(&left.created_at));
+        data.completions.sort_by(|left, right| {
+            right
+                .date
+                .cmp(&left.date)
+                .then_with(|| left.task_id.cmp(&right.task_id))
+        });
+        data.time_entries
+            .sort_by(|left, right| right.started_at.cmp(&left.started_at));
+        data.task_daily_memos
+            .sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
+    }
+
     async fn test_pool() -> SqlitePool {
         let pool = SqlitePoolOptions::new()
             .max_connections(1)
@@ -889,6 +1024,30 @@ mod tests {
             let result = import_app_data(&pool, &data).await.unwrap();
             assert_eq!(result.imported, true);
             assert_eq!(load_app_data_from_pool(&pool).await.unwrap(), data);
+        });
+    }
+
+    #[test]
+    fn imports_representative_legacy_history_without_resetting_the_database() {
+        tauri::async_runtime::block_on(async {
+            let pool = test_pool().await;
+            let data = representative_legacy_data();
+
+            import_app_data(&pool, &data).await.unwrap();
+
+            let mut loaded = load_app_data_from_pool(&pool).await.unwrap();
+            let mut expected = data.clone();
+            normalize_loaded_order(&mut loaded);
+            normalize_loaded_order(&mut expected);
+            assert_eq!(loaded, expected);
+            assert_eq!(migration_marker(&pool).await.unwrap().as_deref(), Some("1"));
+
+            let second = import_app_data(&pool, &data).await.unwrap();
+            assert_eq!(second.imported, false);
+            assert_eq!(second.skipped_existing_data, false);
+            let mut reloaded = load_app_data_from_pool(&pool).await.unwrap();
+            normalize_loaded_order(&mut reloaded);
+            assert_eq!(reloaded, expected);
         });
     }
 

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -1,0 +1,86 @@
+# v0.1 foundation validation
+
+This document records the final validation for the v0.1 foundation described
+by issue #10 and its parent Epic #4.
+
+## Product direction
+
+- FrilDay is described as a timer-first time planning application in the
+  [README](../README.md) and desktop documentation.
+- The product loop remains `Plan → Execute → Track → Review → Adjust`.
+- Planned minutes and actual minutes are separate values in the core model and
+  the Today surface. Completion is stored and toggled independently.
+- The repository contains no new authentication, cloud sync, mobile/web
+  client, generic Pomodoro, or unrelated dashboard scope for this foundation.
+
+## Architecture direction
+
+The effective desktop path is:
+
+```text
+React → Tauri adapter → frilday-core → SQLite adapter
+```
+
+The boundary is documented in [ARCHITECTURE.md](ARCHITECTURE.md) and enforced
+by the typed persistence-boundary test. `crates/frilday-core` has no runtime,
+UI, transport, or persistence dependencies. React calls typed Tauri/core
+operations and does not issue SQLite queries directly. `apps/server` remains
+an optional, buildable future adapter.
+
+## Data migration coverage
+
+The Tauri persistence tests import and load a representative legacy fixture
+containing:
+
+- active and archived tasks;
+- weekday, weekend, and custom schedules with multiple days;
+- `autoArchiveAfter` and `repeatCount` limits;
+- current and historical completions;
+- ended and running time entries, including an archived task's history; and
+- daily memos for historical and current dates.
+
+The fixture is loaded from SQLite after import, compared with the source
+records, and imported a second time to verify idempotence. The migration marker
+is written only after the transaction commits, and existing database records
+are preserved.
+
+## Automated checks
+
+Run from the repository root unless noted otherwise:
+
+| Check | Result |
+| --- | --- |
+| `bun install --frozen-lockfile` in `apps/desktop` | pass |
+| `bun run test` in `apps/desktop` | pass — 8 tests |
+| `bun run lint` in `apps/desktop` | pass |
+| `bun run build` in `apps/desktop` | pass |
+| `cargo fmt --all -- --check` | pass |
+| `cargo check --workspace --locked` | pass |
+| `cargo test --workspace --locked` | pass — 17 core tests, 8 desktop adapter tests |
+
+The Tauri JavaScript packages are kept on the same minor release line as the
+Rust Tauri packages so `bunx tauri dev` starts without a package version
+mismatch warning.
+
+## Manual desktop smoke test
+
+The Tauri development application was launched successfully with the native
+runner against an isolated validation application configuration, and it
+created the expected `daily_check.db` schema without changing existing local
+data. The Tauri package version warning was also absent after aligning the JS
+and Rust package minor releases.
+
+The intended action walkthrough against that isolated configuration is:
+
+1. load existing data;
+2. create, edit, and archive a routine;
+3. find today's applicable routine;
+4. start and stop a session;
+5. toggle completion independently of tracked time; and
+6. restart and verify the result remains.
+
+The host environment does not grant Assistive Access or expose a display to
+this validation run, so GUI clicks and visual confirmation of those six steps
+could not be completed here. The same persistence and core transitions are
+covered by the native adapter tests above; a human desktop run is still
+required before closing Epic #4.


### PR DESCRIPTION
Refs #10

## Summary
- Add a representative legacy-data SQLite round-trip test covering active and archived tasks, multiple schedules/categories, limits, historical completions and time entries, running sessions, and daily memos.
- Record the v0.1 product, architecture, migration, and automated validation evidence in `docs/VALIDATION.md`.
- Align Tauri JavaScript package minor releases with the Rust runtime packages so the native dev app starts without the version mismatch warning.

## Validation
- `bun install --frozen-lockfile`
- `bun run test` — 8 tests pass
- `bun run lint` — pass
- `bun run build` — pass
- `cargo fmt --all -- --check` — pass
- `cargo check --workspace --locked` — pass
- `cargo test --workspace --locked` — 17 core tests and 8 desktop adapter tests pass
- `bunx tauri dev` — native runner starts and creates the expected isolated SQLite schema without the package mismatch warning

## Follow-up
The host validation environment does not grant macOS Assistive Access or expose a display, so the six GUI click-through smoke steps could not be completed. Epic #4 should remain open until a human desktop run verifies the interaction flow.