### PR TITLE
[Feature] Redesign Today around one-tap plan execution

### DIFF
--- a/apps/desktop/src/app/App.tsx
+++ b/apps/desktop/src/app/App.tsx
@@ -50,16 +50,6 @@ export default function App() {
                 <h1 className="text-2xl font-semibold tracking-tight">
                   FrilDay
                 </h1>
-
-                <div className="mb-3 block sm:hidden">
-                  <h2 className="text-base font-semibold text-zinc-100">
-                    {t('common.today')}
-                  </h2>
-                  <p className="mt-1 text-sm text-zinc-400">
-                    {m.todayYmd}{' '}
-                    <span className="text-zinc-500">({m.todayDow})</span>
-                  </p>
-                </div>
               </div>
 
               <div className="md:pt-1">
@@ -81,7 +71,6 @@ export default function App() {
                 todayDow={m.todayDow}
                 todayTasks={m.todayTasks}
                 todayStats={m.todayStats}
-                periodStats={m.periodStats}
                 todayTimeTotals={m.todayTimeTotals}
                 taskDayStates={m.taskDayStates}
                 completions={m.completions}

--- a/apps/desktop/src/app/hooks/useAppModel.ts
+++ b/apps/desktop/src/app/hooks/useAppModel.ts
@@ -5,6 +5,7 @@ import type { Task, TaskDayState } from '../../shared/types';
 import type { Tab } from '../layout/HeaderTabs';
 import type { CreateTaskInput } from '../../features/task/components/TaskForm';
 import type { ActiveTimerPhase } from '../../features/timer/activeTimerModel';
+import { useLocale } from '../../i18n/useLocale';
 import { getNotifier } from '../di/notifierDI';
 import { getDailyMemoText } from '../../domain/memo';
 import {
@@ -46,6 +47,7 @@ function monthStartYmd(ymd: string): string {
 }
 
 export function useAppModel() {
+  const { t } = useLocale();
   const {
     hydrated,
     tasks,
@@ -101,6 +103,9 @@ export function useAppModel() {
   );
   const [activeTimerPhase, setActiveTimerPhase] =
     useState<ActiveTimerPhase>('ready');
+  const [pendingTimerTaskId, setPendingTimerTaskId] = useState<string | null>(
+    null,
+  );
   const [scheduleSlots, setScheduleSlots] = useState<
     Awaited<ReturnType<typeof getVisibleScheduleSlots>>
   >([]);
@@ -274,8 +279,44 @@ export function useAppModel() {
       if (running) return running;
     }
 
-    return todayTasks.find((task) => !visibleToday.get(task.id)?.completed) ?? null;
-  }, [activeTimerTaskId, runningTaskId, tasks, todayTasks, visibleToday]);
+    return null;
+  }, [activeTimerTaskId, runningTaskId, tasks]);
+
+  // Adopt a session restored from storage so it remains visible after an
+  // automatic stop as a finished execution instead of disappearing abruptly.
+  useEffect(() => {
+    if (runningTaskId == null || activeTimerTaskId != null) return;
+    setActiveTimerTaskId(runningTaskId);
+    setActiveTimerPhase('running');
+  }, [activeTimerTaskId, runningTaskId]);
+
+  // Auto-stop ends the persisted session without going through the button
+  // handlers. Reflect that transition in the execution surface once the
+  // running-session lookup catches up.
+  useEffect(() => {
+    if (
+      !hydrated ||
+      activeTimerTaskId == null ||
+      activeTimerPhase !== 'running' ||
+      pendingTimerTaskId === activeTimerTaskId
+    ) {
+      return;
+    }
+
+    const hasRunningEntry = timeEntries.some(
+      (entry) => entry.taskId === activeTimerTaskId && entry.endedAt == null,
+    );
+    if (runningTaskId == null && !hasRunningEntry) {
+      setActiveTimerPhase('finished');
+    }
+  }, [
+    activeTimerPhase,
+    activeTimerTaskId,
+    hydrated,
+    pendingTimerTaskId,
+    runningTaskId,
+    timeEntries,
+  ]);
 
   const activeTimerPhaseForView: ActiveTimerPhase =
     activeTimerTask == null
@@ -283,11 +324,7 @@ export function useAppModel() {
       : runningTaskId === activeTimerTask.id
         ? 'running'
         : activeTimerTaskId === activeTimerTask.id
-          ? activeTimerPhase === 'paused'
-            ? 'paused'
-            : activeTimerPhase === 'finished'
-              ? 'finished'
-              : 'ready'
+          ? activeTimerPhase
           : 'ready';
 
   const setError = (msg: string) =>
@@ -355,10 +392,34 @@ export function useAppModel() {
   };
 
   // 실시간을 위해 today(useMemo) 대신 현재 날짜 받기
-  const handleStartTimer = (task: Task) => {
+  const handleStartTimer = async (task: Task) => {
+    const currentTask =
+      runningTaskId == null
+        ? activeTimerPhase === 'running'
+          ? activeTimerTask
+          : null
+        : tasks.find((candidate) => candidate.id === runningTaskId) ?? null;
+
+    if (currentTask && currentTask.id !== task.id) {
+      const shouldSwitch = window.confirm(
+        t('timer.switchConfirm', {
+          current: currentTask.title,
+          next: task.title,
+        }),
+      );
+      if (!shouldSwitch) return;
+    }
+
     setActiveTimerTaskId(task.id);
     setActiveTimerPhase('running');
-    startTimer({ taskId: task.id, today: new Date() });
+    setPendingTimerTaskId(task.id);
+    try {
+      await startTimer({ taskId: task.id, today: new Date() });
+    } finally {
+      setPendingTimerTaskId((pending) =>
+        pending === task.id ? null : pending,
+      );
+    }
 
     notifier.notify({
       level: 'info',
@@ -366,20 +427,27 @@ export function useAppModel() {
     });
   };
 
-  const handleStopTimer = (task: Task) => {
+  const handleStopTimer = async (task: Task) => {
     setActiveTimerTaskId(task.id);
     setActiveTimerPhase('paused');
-    stopTimer({ taskId: task.id, today: new Date() });
+    await stopTimer({ taskId: task.id, today: new Date() });
     notifier.notify({
       level: 'info',
       message: `Timer paused`,
     });
   };
 
-  const handleResumeTimer = (task: Task) => {
+  const handleResumeTimer = async (task: Task) => {
     setActiveTimerTaskId(task.id);
     setActiveTimerPhase('running');
-    startTimer({ taskId: task.id, today: new Date() });
+    setPendingTimerTaskId(task.id);
+    try {
+      await startTimer({ taskId: task.id, today: new Date() });
+    } finally {
+      setPendingTimerTaskId((pending) =>
+        pending === task.id ? null : pending,
+      );
+    }
 
     notifier.notify({
       level: 'info',

--- a/apps/desktop/src/app/hooks/useAppModel.ts
+++ b/apps/desktop/src/app/hooks/useAppModel.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useFrilDayStore } from '../store/useFrilDayStore';
 import { dayOfWeek, startOfWeekMonday, toYmd } from '../../shared/utils/date';
 import type { Task, TaskDayState } from '../../shared/types';
@@ -106,6 +106,7 @@ export function useAppModel() {
   const [pendingTimerTaskId, setPendingTimerTaskId] = useState<string | null>(
     null,
   );
+  const pendingTimerStarts = useRef(new Set<string>());
   const [scheduleSlots, setScheduleSlots] = useState<
     Awaited<ReturnType<typeof getVisibleScheduleSlots>>
   >([]);
@@ -392,7 +393,9 @@ export function useAppModel() {
   };
 
   // 실시간을 위해 today(useMemo) 대신 현재 날짜 받기
-  const handleStartTimer = async (task: Task) => {
+  const startTimerForTask = async (task: Task, message: string) => {
+    if (pendingTimerStarts.current.has(task.id)) return;
+
     const currentTask =
       runningTaskId == null
         ? activeTimerPhase === 'running'
@@ -410,49 +413,60 @@ export function useAppModel() {
       if (!shouldSwitch) return;
     }
 
+    const previousTaskId = activeTimerTask?.id ?? runningTaskId;
+    const previousPhase = activeTimerPhaseForView;
+    pendingTimerStarts.current.add(task.id);
     setActiveTimerTaskId(task.id);
     setActiveTimerPhase('running');
     setPendingTimerTaskId(task.id);
     try {
-      await startTimer({ taskId: task.id, today: new Date() });
+      const result = await startTimer({ taskId: task.id, today: new Date() });
+      if (!result.ok) {
+        setActiveTimerTaskId(previousTaskId ?? null);
+        setActiveTimerPhase(previousTaskId == null ? 'ready' : previousPhase);
+        return;
+      }
+
+      if (result.changed) {
+        notifier.notify({
+          level: 'info',
+          message,
+        });
+      }
     } finally {
+      pendingTimerStarts.current.delete(task.id);
       setPendingTimerTaskId((pending) =>
         pending === task.id ? null : pending,
       );
     }
+  };
 
-    notifier.notify({
-      level: 'info',
-      message: `Timer started`,
-    });
+  const handleStartTimer = (task: Task) => {
+    void startTimerForTask(task, 'Timer started');
   };
 
   const handleStopTimer = async (task: Task) => {
+    const previousTaskId = activeTimerTask?.id ?? runningTaskId;
+    const previousPhase = activeTimerPhaseForView;
     setActiveTimerTaskId(task.id);
     setActiveTimerPhase('paused');
-    await stopTimer({ taskId: task.id, today: new Date() });
-    notifier.notify({
-      level: 'info',
-      message: `Timer paused`,
-    });
-  };
-
-  const handleResumeTimer = async (task: Task) => {
-    setActiveTimerTaskId(task.id);
-    setActiveTimerPhase('running');
-    setPendingTimerTaskId(task.id);
-    try {
-      await startTimer({ taskId: task.id, today: new Date() });
-    } finally {
-      setPendingTimerTaskId((pending) =>
-        pending === task.id ? null : pending,
-      );
+    const result = await stopTimer({ taskId: task.id, today: new Date() });
+    if (!result.ok) {
+      setActiveTimerTaskId(previousTaskId ?? null);
+      setActiveTimerPhase(previousTaskId == null ? 'ready' : previousPhase);
+      return;
     }
 
-    notifier.notify({
-      level: 'info',
-      message: `Timer resumed`,
-    });
+    if (result.changed) {
+      notifier.notify({
+        level: 'info',
+        message: `Timer paused`,
+      });
+    }
+  };
+
+  const handleResumeTimer = (task: Task) => {
+    void startTimerForTask(task, 'Timer resumed');
   };
 
   const handleFinishTimer = async (task: Task) => {
@@ -460,7 +474,8 @@ export function useAppModel() {
       (entry) => entry.taskId === task.id && entry.endedAt == null,
     );
     if (runningTaskId === task.id || hasRunningEntry) {
-      await stopTimer({ taskId: task.id, today: new Date() });
+      const result = await stopTimer({ taskId: task.id, today: new Date() });
+      if (!result.ok) return;
     }
 
     setActiveTimerPhase('finished');

--- a/apps/desktop/src/app/pages/TodayPage.tsx
+++ b/apps/desktop/src/app/pages/TodayPage.tsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
+import clsx from 'clsx';
 import { TaskList } from '../../features/task/components/TaskList';
-import { PeriodStatsPanel } from '../../features/statistics/components/PeriodStatsPanel';
 import type {
   Task,
   Completion,
@@ -54,7 +54,6 @@ export function TodayPage(props: {
   todayTasks: Task[]; // (role: tasks scheduled today, type: Task[])
 
   todayStats: CoreStatistics['today']; // (role: core-derived today stats, type: CoreStatistics['today'])
-  periodStats: CoreStatistics;
   todayTimeTotals: CoreTimeTotals;
   taskDayStates: ReadonlyMap<string, TaskDayState>;
 
@@ -86,7 +85,6 @@ export function TodayPage(props: {
     todayDow,
     todayTasks,
     todayStats,
-    periodStats,
     todayTimeTotals,
     taskDayStates,
 
@@ -118,150 +116,123 @@ export function TodayPage(props: {
       : clamp((spentMinutesToday / plannedMinutesToday) * 100, 0, 100);
 
   return (
-    <div className="grid gap-3 md:gap-4 xl:grid-cols-[360px_1fr] xl:items-start">
-      <aside className="min-w-0 xl:space-y-4 xl:sticky xl:top-6">
-        <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
-          <div className="mb-3">
-            <div className="flex items-start justify-between gap-3">
-              <div className="min-w-0">
-                <h2 className="text-base font-semibold text-zinc-100">
-                  {t('common.today')}
-                </h2>
-                <p className="mt-1 hidden text-sm text-zinc-400 sm:block">
-                  {todayYmd} <span className="text-zinc-500">({todayDow})</span>
-                </p>
-              </div>
-            </div>
-          </div>
-
-          <div className="grid gap-3 sm:grid-cols-3 xl:grid-cols-1">
-            <div className="rounded-2xl border border-zinc-800 bg-zinc-950/40 p-4 hidden sm:block">
-              <div className="text-xs font-medium text-zinc-400">
-                {t('stats.scheduledToday')}
-              </div>
-              <div className="mt-2 text-2xl font-semibold text-zinc-100">
-                {todayStats.scheduledCount}
-              </div>
-            </div>
-
-            <div className="rounded-2xl border border-zinc-800 bg-zinc-950/40 p-4 hidden sm:block">
-              <div className="text-xs font-medium text-zinc-400">
-                {t('stats.done')}
-              </div>
-              <div className="mt-2 text-2xl font-semibold text-zinc-100">
-                {todayStats.completedCount}
-              </div>
-            </div>
-
-            <div className="rounded-2xl border border-zinc-800 bg-zinc-950/40 p-4">
-              <div className="text-xs font-medium text-zinc-400">
-                {t('common.completion')}
-              </div>
-
-              <div className="mt-2 flex items-end justify-between gap-3">
-                <div className="flex items-baseline gap-2">
-                  <div className="text-2xl font-semibold text-zinc-100">
-                    {todayStats.rate.toFixed(0)}%
-                  </div>
-                  <div className="text-xs text-zinc-500">
-                    ({todayStats.completedCount}/{todayStats.scheduledCount})
-                  </div>
-                </div>
-              </div>
-
-              <ProgressBar value={todayStats.rate} />
-            </div>
-          </div>
-        </section>
-
-        <section className="hidden rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4 xl:block">
-          <PeriodStatsPanel
-            stats={periodStats}
-          />
-        </section>
-      </aside>
-
-      <main className="min-w-0 space-y-4">
-        {activeTimerTask && (
-          <ActiveTimer
-            task={activeTimerTask}
-            timeEntries={timeEntries}
-            dateYmd={todayYmd}
-            nowIso={nowIso}
-            phase={activeTimerPhase}
-            onStart={() => onStartTimer(activeTimerTask)}
-            onPause={() => onPauseTimer(activeTimerTask)}
-            onResume={() => onResumeTimer(activeTimerTask)}
-            onFinish={() => onFinishTimer(activeTimerTask)}
-            onBackToPlan={onBackToPlan}
-          />
-        )}
-
-        <section className="hidden rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4 md:block">
-          <div className="flex items-start justify-between gap-4">
-            <div className="min-w-0">
-              <div className="text-xs font-medium text-zinc-400">
-                {t('common.time')}
-              </div>
-
-              <div className="mt-2 flex flex-wrap items-baseline gap-x-2 gap-y-1">
-                <div className="text-2xl font-semibold text-zinc-100">
-                  {formatMinutes(spentMinutesToday, t)}
-                </div>
-                <div className="text-xs text-zinc-500">
-                  / {formatMinutes(plannedMinutesToday, t)}
-                </div>
-              </div>
-            </div>
-
-            <div className="shrink-0 text-sm font-semibold text-zinc-100">
-              {timeProgressPct.toFixed(0)}%
-            </div>
-          </div>
-
-          <ProgressBar value={timeProgressPct} />
-
-          <div className="mt-2 text-xs text-zinc-500">
-            {t('time.basedOnTodayPlannedMinutes')}
-          </div>
-        </section>
-
-        <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
-          <div className="mb-3">
-            <h2 className="text-base font-semibold text-zinc-100">
-              {t('task.todayTasks')}
+    <div className="mx-auto max-w-5xl space-y-4">
+      <header className="rounded-3xl border border-zinc-800 bg-zinc-900/40 px-5 py-5 sm:px-7">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-emerald-300/80">
+              {t('common.today')}
+            </p>
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-zinc-50 sm:text-3xl">
+              {todayYmd}{' '}
+              <span className="text-zinc-500">({todayDow})</span>
             </h2>
-            <p className="mt-1 text-sm text-zinc-400">
-              {t('task.todayTasksDescription')}
+            <p className="mt-2 text-sm text-zinc-400">
+              {activeTimerTask
+                ? t('today.activeExecutionHint')
+                : t('today.executionHint')}
             </p>
           </div>
 
-          <TaskList
-            variant="today"
-            tasks={todayTasks}
-            completions={completions}
-            timeEntries={timeEntries}
-            todayYmd={todayYmd}
-            todayDow={todayDow}
-            nowIso={nowIso}
-            runningTaskId={runningTaskId}
-            getMemoText={getMemoText}
-            onSaveMemo={onSaveMemo}
-            onToggleToday={onToggleToday}
-            onArchive={onArchive}
-            onStartTimer={onStartTimer}
-            onStopTimer={onStopTimer}
-            onError={onError}
-            taskDayStates={taskDayStates}
-          />
+          <div className="rounded-full border border-zinc-700 bg-zinc-950/50 px-3 py-1.5 text-sm text-zinc-300">
+            {todayStats.completedCount}/{todayStats.scheduledCount}{' '}
+            {t('stats.done')}
+          </div>
+        </div>
+      </header>
 
-          {todayTasks.length === 0 && (
-            <div className="mt-3 rounded-xl border border-zinc-800 bg-zinc-950/40 p-4 text-sm text-zinc-500">
-              {t('task.noTasksScheduledToday')}
+      {activeTimerTask && (
+        <ActiveTimer
+          task={activeTimerTask}
+          timeEntries={timeEntries}
+          dateYmd={todayYmd}
+          nowIso={nowIso}
+          phase={activeTimerPhase}
+          onStart={() => onStartTimer(activeTimerTask)}
+          onPause={() => onPauseTimer(activeTimerTask)}
+          onResume={() => onResumeTimer(activeTimerTask)}
+          onFinish={() => onFinishTimer(activeTimerTask)}
+          onBackToPlan={onBackToPlan}
+        />
+      )}
+
+      <section className="rounded-3xl border border-zinc-800 bg-zinc-900/40 px-5 py-5 sm:px-7">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-zinc-500">
+              {t('common.time')}
+            </p>
+            <div className="mt-2 flex flex-wrap items-baseline gap-x-2 gap-y-1">
+              <span className="text-2xl font-semibold text-zinc-50 sm:text-3xl">
+                {formatMinutes(spentMinutesToday, t)}
+              </span>
+              <span className="text-sm text-zinc-500">
+                / {formatMinutes(plannedMinutesToday, t)}
+              </span>
             </div>
-          )}
-        </section>
-      </main>
+          </div>
+
+          <div className="text-right">
+            <p className="text-xs text-zinc-500">{t('time.plannedVsActual')}</p>
+            <p className="mt-1 text-sm font-semibold text-zinc-200">
+              {timeProgressPct.toFixed(0)}%
+            </p>
+          </div>
+        </div>
+
+        <ProgressBar value={timeProgressPct} />
+
+        <div className="mt-2 flex flex-wrap justify-between gap-2 text-xs text-zinc-500">
+          <span>{t('time.trackedToday')}</span>
+          <span>
+            {todayStats.completedCount}/{todayStats.scheduledCount}{' '}
+            {t('stats.done')}
+          </span>
+        </div>
+      </section>
+
+      <section
+        className={clsx(
+          'rounded-3xl border border-zinc-800 bg-zinc-900/40 px-5 py-5 transition-opacity sm:px-7',
+          activeTimerTask && 'opacity-90',
+        )}>
+        <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <h2 className="text-base font-semibold text-zinc-100 sm:text-lg">
+              {t('task.todayTasks')}
+            </h2>
+            <p className="mt-1 text-sm text-zinc-400">
+              {activeTimerTask
+                ? t('task.todayTasksDuringExecution')
+                : t('task.todayTasksDescription')}
+            </p>
+          </div>
+          <span className="text-xs text-zinc-500">
+            {todayTasks.length} {t('task.plansToday')}
+          </span>
+        </div>
+
+        <TaskList
+          variant="today"
+          tasks={todayTasks}
+          completions={completions}
+          timeEntries={timeEntries}
+          todayYmd={todayYmd}
+          todayDow={todayDow}
+          nowIso={nowIso}
+          runningTaskId={runningTaskId}
+          getMemoText={getMemoText}
+          onSaveMemo={onSaveMemo}
+          onToggleToday={onToggleToday}
+          onArchive={onArchive}
+          onStartTimer={onStartTimer}
+          onStopTimer={onStopTimer}
+          onError={onError}
+          taskDayStates={taskDayStates}
+          isExecutionFocused={Boolean(activeTimerTask)}
+          emptyMessage={t('task.noTasksScheduledToday')}
+        />
+      </section>
     </div>
   );
 }

--- a/apps/desktop/src/app/store/useFrilDayStore.ts
+++ b/apps/desktop/src/app/store/useFrilDayStore.ts
@@ -70,8 +70,8 @@ interface FrilDayState {
   deleteTask: (taskId: string) => void;
   toggleToday: (input: { taskId: string; today: Date }) => Promise<void>;
   setDailyMemo: (input: { taskId: string; date: string; text: string }) => void;
-  startTimer: (input: { taskId: string; today: Date }) => Promise<void>;
-  stopTimer: (input: { taskId: string; today: Date }) => Promise<void>;
+  startTimer: (input: { taskId: string; today: Date }) => Promise<TimerMutationResult>;
+  stopTimer: (input: { taskId: string; today: Date }) => Promise<TimerMutationResult>;
   autoStopIfReached: () => Promise<string[]>;
 }
 
@@ -95,6 +95,11 @@ function formatError(error: unknown): string {
   }
 }
 
+type TimerMutationResult = {
+  ok: boolean;
+  changed: boolean;
+};
+
 function persist(
   operation: AsyncOperation,
   failureMessage: string,
@@ -111,7 +116,7 @@ const enqueuePersistence = createSerialQueue();
 const enqueueCompletionToggle = createSerialQueue();
 // Serialize starts and stops so two quick actions cannot observe the same
 // stale session list and create competing active sessions.
-const enqueueTimerMutation = createSerialQueue();
+const enqueueTimerMutation = createSerialQueue<TimerMutationResult>();
 
 export const useFrilDayStore = create<FrilDayState>((set, get) => ({
   hydrated: false,
@@ -377,6 +382,11 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
       const nowIso = new Date().toISOString();
 
       const entries = get().timeEntries;
+      const runningEntry = entries.find((entry) => entry.endedAt == null);
+      if (runningEntry?.taskId === taskId) {
+        return { ok: true, changed: false };
+      }
+
       try {
         const nextTimeEntries = await startTimerWithCore({
           timeEntries: entries,
@@ -390,8 +400,10 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
           () => saveTimeEntries(nextTimeEntries),
           'Failed to start timer.',
         );
+        return { ok: true, changed: true };
       } catch (error) {
         set({ errorMsg: `Failed to start timer. ${formatError(error)}` });
+        return { ok: false, changed: false };
       }
     }),
 
@@ -399,6 +411,13 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
     enqueueTimerMutation(async () => {
       const date = toYmd(today);
       const nowIso = new Date().toISOString();
+      const hasRunningEntry = get().timeEntries.some(
+        (entry) => entry.taskId === taskId && entry.endedAt == null,
+      );
+      if (!hasRunningEntry) {
+        return { ok: false, changed: false };
+      }
+
       try {
         const nextTimeEntries = await stopTimerWithCore({
           timeEntries: get().timeEntries,
@@ -411,8 +430,10 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
           () => saveTimeEntries(nextTimeEntries),
           'Failed to stop timer.',
         );
+        return { ok: true, changed: true };
       } catch (error) {
         set({ errorMsg: `Failed to stop timer. ${formatError(error)}` });
+        return { ok: false, changed: false };
       }
     }),
 

--- a/apps/desktop/src/app/store/useFrilDayStore.ts
+++ b/apps/desktop/src/app/store/useFrilDayStore.ts
@@ -109,6 +109,9 @@ function persist(
 
 const enqueuePersistence = createSerialQueue();
 const enqueueCompletionToggle = createSerialQueue();
+// Serialize starts and stops so two quick actions cannot observe the same
+// stale session list and create competing active sessions.
+const enqueueTimerMutation = createSerialQueue();
 
 export const useFrilDayStore = create<FrilDayState>((set, get) => ({
   hydrated: false,
@@ -368,48 +371,50 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
     persist(() => saveTaskDailyMemo(memo), 'Failed to save memo.');
   },
 
-  startTimer: async ({ taskId, today }) => {
-    const date = toYmd(today);
-    const nowIso = new Date().toISOString();
+  startTimer: ({ taskId, today }) =>
+    enqueueTimerMutation(async () => {
+      const date = toYmd(today);
+      const nowIso = new Date().toISOString();
 
-    const entries = get().timeEntries;
-    try {
-      const nextTimeEntries = await startTimerWithCore({
-        timeEntries: entries,
-        sessionId: uid(),
-        taskId,
-        dateYmd: date,
-        startedAt: nowIso,
-      });
-      set({ timeEntries: nextTimeEntries, errorMsg: '' });
-      persist(
-        () => saveTimeEntries(nextTimeEntries),
-        'Failed to start timer.',
-      );
-    } catch (error) {
-      set({ errorMsg: `Failed to start timer. ${formatError(error)}` });
-    }
-  },
+      const entries = get().timeEntries;
+      try {
+        const nextTimeEntries = await startTimerWithCore({
+          timeEntries: entries,
+          sessionId: uid(),
+          taskId,
+          dateYmd: date,
+          startedAt: nowIso,
+        });
+        set({ timeEntries: nextTimeEntries, errorMsg: '' });
+        persist(
+          () => saveTimeEntries(nextTimeEntries),
+          'Failed to start timer.',
+        );
+      } catch (error) {
+        set({ errorMsg: `Failed to start timer. ${formatError(error)}` });
+      }
+    }),
 
-  stopTimer: async ({ taskId, today }) => {
-    const date = toYmd(today);
-    const nowIso = new Date().toISOString();
-    try {
-      const nextTimeEntries = await stopTimerWithCore({
-        timeEntries: get().timeEntries,
-        taskId,
-        dateYmd: date,
-        endedAt: nowIso,
-      });
-      set({ timeEntries: nextTimeEntries, errorMsg: '' });
-      persist(
-        () => saveTimeEntries(nextTimeEntries),
-        'Failed to stop timer.',
-      );
-    } catch (error) {
-      set({ errorMsg: `Failed to stop timer. ${formatError(error)}` });
-    }
-  },
+  stopTimer: ({ taskId, today }) =>
+    enqueueTimerMutation(async () => {
+      const date = toYmd(today);
+      const nowIso = new Date().toISOString();
+      try {
+        const nextTimeEntries = await stopTimerWithCore({
+          timeEntries: get().timeEntries,
+          taskId,
+          dateYmd: date,
+          endedAt: nowIso,
+        });
+        set({ timeEntries: nextTimeEntries, errorMsg: '' });
+        persist(
+          () => saveTimeEntries(nextTimeEntries),
+          'Failed to stop timer.',
+        );
+      } catch (error) {
+        set({ errorMsg: `Failed to stop timer. ${formatError(error)}` });
+      }
+    }),
 
   autoStopIfReached: async () => {
     if (!get().hydrated) return [];

--- a/apps/desktop/src/features/task/components/TaskList.tsx
+++ b/apps/desktop/src/features/task/components/TaskList.tsx
@@ -6,6 +6,7 @@ import type {
   TaskDayState,
   TimeEntry,
 } from '../types';
+import clsx from 'clsx';
 import { LocaleContext } from '../../../i18n/context';
 import { TaskListItem } from './TaskListItem';
 
@@ -40,6 +41,8 @@ interface TaskListProps {
 
   onError: (msg: string) => void;
   taskDayStates: ReadonlyMap<string, TaskDayState>;
+  isExecutionFocused?: boolean;
+  emptyMessage?: string;
 }
 
 export function TaskList(props: TaskListProps) {
@@ -49,13 +52,17 @@ export function TaskList(props: TaskListProps) {
   if (tasks.length === 0) {
     return (
       <div className="rounded-xl border border-zinc-800 bg-zinc-950/40 p-4 text-sm text-zinc-500">
-        {t('task.noTasks')}
+        {props.emptyMessage ?? t('task.noTasks')}
       </div>
     );
   }
 
   return (
-    <div className="space-y-2">
+    <div
+      className={clsx(
+        'space-y-2 transition-opacity',
+        props.isExecutionFocused && 'opacity-75',
+      )}>
       {tasks.map((t) => (
         <TaskListItem
           key={t.id}
@@ -78,6 +85,7 @@ export function TaskList(props: TaskListProps) {
           onStopTimer={props.onStopTimer}
           onError={props.onError}
           taskDayState={props.taskDayStates.get(t.id)}
+          isExecutionFocused={props.isExecutionFocused}
         />
       ))}
     </div>

--- a/apps/desktop/src/features/task/components/TaskListItem.tsx
+++ b/apps/desktop/src/features/task/components/TaskListItem.tsx
@@ -39,6 +39,7 @@ interface TaskListItemProps {
   }) => void; // (role: update task fields, type: ((input)=>void) | undefined)
   onError: (msg: string) => void; // (role: set error message, type: (string)=>void)
   taskDayState?: TaskDayState;
+  isExecutionFocused?: boolean;
 }
 
 export function TaskListItem(props: TaskListItemProps) {
@@ -60,6 +61,7 @@ export function TaskListItem(props: TaskListItemProps) {
     onUpdateTaskMeta,
     onError,
     taskDayState,
+    isExecutionFocused,
   } = props;
 
   const scheduledToday = taskDayState?.scheduled ?? false;
@@ -83,6 +85,7 @@ export function TaskListItem(props: TaskListItemProps) {
   const totalMinutesToday = taskDayState?.actualMinutes ?? 0;
 
   const plannedMinutes = Math.max(0, task.durationMinutes || 0);
+  const hasTrackedTime = totalMinutesToday > 0;
 
   // Completion and tracked time are independent. A manual completion must not
   // make the actual-time progress look like the planned time was spent.
@@ -189,6 +192,7 @@ export function TaskListItem(props: TaskListItemProps) {
           ? 'border-zinc-800 bg-zinc-950/40'
           : 'border-zinc-900 bg-zinc-950/20 opacity-80',
         variant == 'today' ? 'xl:px-5 xl:pt-5' : '',
+        isExecutionFocused && running && 'border-emerald-300/30',
       )}>
       <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
         <div className="min-w-0 w-full md:max-w-[64%]">
@@ -197,9 +201,11 @@ export function TaskListItem(props: TaskListItemProps) {
               {task.title}
             </div>
 
-            <span className="rounded-full border border-zinc-800 bg-zinc-900/40 px-2 py-0.5 text-xs text-zinc-300">
-              {categoryLabel}
-            </span>
+            {variant === 'manage' && (
+              <span className="rounded-full border border-zinc-800 bg-zinc-900/40 px-2 py-0.5 text-xs text-zinc-300">
+                {categoryLabel}
+              </span>
+            )}
 
             {!task.isActive && (
               <span className="rounded-full border border-zinc-700 bg-zinc-800/40 px-2 py-0.5 text-xs text-zinc-300">
@@ -208,25 +214,29 @@ export function TaskListItem(props: TaskListItemProps) {
             )}
           </div>
 
-          {description && (
+          {description && variant === 'manage' && (
             <p className="mt-1 truncate text-xs text-zinc-400">{description}</p>
           )}
 
           <div className="mt-1 text-xs text-zinc-500">
-            <span
-              className={clsx(
-                variant == 'today' ? 'hidden md:inline-block' : 'inline-block',
-              )}>
-              {tr('task.days')}: {daysLabel} ·
-            </span>{' '}
-            {tr('task.plan')}: {task.durationMinutes}
-            {tr('time.minuteShort')}{' '}
-            <span
-              className={clsx(variant == 'today' ? 'inline-block' : 'hidden')}>
-              · {tr('task.todaySpent')}:{' '}
-              {totalMinutesToday}
-              {tr('time.minuteShort')}
-            </span>
+            {variant === 'manage' && (
+              <span>
+                {tr('task.days')}: {daysLabel} ·{' '}
+              </span>
+            )}
+            {variant === 'manage' ? (
+              <>
+                {tr('task.plan')}: {task.durationMinutes}
+                {tr('time.minuteShort')}
+              </>
+            ) : (
+              <>
+                {tr('task.planned')}: {plannedMinutes}
+                {tr('time.minuteShort')} · {tr('task.actualTracked')}:{' '}
+                {totalMinutesToday}
+                {tr('time.minuteShort')}
+              </>
+            )}
             {task.autoArchiveAfter != null && (
               <span className="ml-2 text-zinc-400">
                 · {tr('task.autoArchiveAfter')}: {autoArchiveProgressLabel}
@@ -234,7 +244,7 @@ export function TaskListItem(props: TaskListItemProps) {
             )}
             {running && (
               <span className="ml-2 text-emerald-200">
-                {tr('common.running')}
+                · {tr('common.running')}
               </span>
             )}
             {!scheduledToday && (
@@ -296,7 +306,7 @@ export function TaskListItem(props: TaskListItemProps) {
               ) : (
                 <span className="flex items-center gap-1">
                   <Play size={14} />
-                  {tr('time.start')}
+                  {hasTrackedTime ? tr('time.resume') : tr('time.start')}
                 </span>
               )}
             </button>

--- a/apps/desktop/src/i18n/messages/en.ts
+++ b/apps/desktop/src/i18n/messages/en.ts
@@ -36,8 +36,13 @@ export const en = {
     schedule: 'Schedule',
     days: 'Days',
     plan: 'Plan',
+    planned: 'Planned',
+    actualTracked: 'Tracked',
     todaySpent: 'Today',
     todayTasksDescription: 'Only tasks scheduled for today are shown here.',
+    todayTasksDuringExecution:
+      'The current session stays in focus while today’s plan remains available below.',
+    plansToday: 'plans',
     manageTasks: 'Manage tasks',
     manageTasksDescription: 'Your tasks list with the current filters.',
     filters: 'Filters',
@@ -91,8 +96,11 @@ export const en = {
   time: {
     durationMin: 'Duration (min)',
     basedOnTodayPlannedMinutes: "Based on today's planned minutes.",
+    plannedVsActual: 'Tracked / planned',
+    trackedToday: 'Actual time tracked today',
     start: 'Start',
     stop: 'Stop',
+    resume: 'Resume',
     hourShort: 'h',
     minuteShort: 'm',
     day: {
@@ -128,6 +136,14 @@ export const en = {
     resume: 'Resume',
     finish: 'Finish',
     backToPlan: 'Back to plan',
+    switchConfirm:
+      'Switch from "{current}" to "{next}"? The current session will be stopped and the new plan will start.',
+  },
+
+  today: {
+    executionHint: 'Start the next plan when you are ready.',
+    activeExecutionHint:
+      'Stay with the current plan. Its actual time is updating now.',
   },
 
   period: {

--- a/apps/desktop/src/i18n/messages/ja.ts
+++ b/apps/desktop/src/i18n/messages/ja.ts
@@ -37,8 +37,13 @@ export const ja = {
     schedule: '予定',
     days: '曜日',
     plan: '計画',
+    planned: '予定',
+    actualTracked: '実績',
     todaySpent: '今日',
     todayTasksDescription: 'ここには今日予定されているタスクのみ表示されます。',
+    todayTasksDuringExecution:
+      '現在のセッションに集中しながら、下で今日の予定を確認できます。',
+    plansToday: '件の予定',
     manageTasks: 'タスク管理',
     manageTasksDescription: '現在のフィルターが適用されたタスクリストです。',
     filters: 'フィルター',
@@ -91,8 +96,11 @@ export const ja = {
   time: {
     durationMin: '時間 (分)',
     basedOnTodayPlannedMinutes: '今日の予定時間(分)を基準にしています。',
+    plannedVsActual: '実績 / 予定',
+    trackedToday: '今日記録した実績時間',
     start: '開始',
     stop: '停止',
+    resume: '再開',
     hourShort: '時間',
     minuteShort: '分',
     day: {
@@ -128,6 +136,13 @@ export const ja = {
     resume: '再開',
     finish: '終了',
     backToPlan: '予定に戻る',
+    switchConfirm:
+      '「{current}」から「{next}」に切り替えますか？現在のセッションを停止して新しい予定を開始します。',
+  },
+
+  today: {
+    executionHint: '準備ができたら次の予定を開始しましょう。',
+    activeExecutionHint: '現在の予定に集中してください。実績時間を記録しています。',
   },
 
   period: {

--- a/apps/desktop/src/i18n/messages/ko.ts
+++ b/apps/desktop/src/i18n/messages/ko.ts
@@ -36,8 +36,13 @@ export const ko = {
     schedule: '일정',
     days: '요일',
     plan: '계획',
+    planned: '계획',
+    actualTracked: '실제 기록',
     todaySpent: '오늘',
     todayTasksDescription: '오늘 일정에 포함된 작업만 표시됩니다.',
+    todayTasksDuringExecution:
+      '현재 세션에 집중하면서 아래에서 오늘 계획을 계속 확인할 수 있습니다.',
+    plansToday: '개 계획',
     manageTasks: '작업 관리',
     manageTasksDescription: '현재 필터가 적용된 작업 목록입니다.',
     filters: '필터',
@@ -91,8 +96,11 @@ export const ko = {
   time: {
     durationMin: '시간 (분)',
     basedOnTodayPlannedMinutes: '오늘 계획된 시간(분) 기준입니다.',
+    plannedVsActual: '실제 기록 / 계획',
+    trackedToday: '오늘 기록한 실제 시간',
     start: '시작',
     stop: '중지',
+    resume: '재개',
     hourShort: '시간',
     minuteShort: '분',
     day: {
@@ -128,6 +136,13 @@ export const ko = {
     resume: '재개',
     finish: '마치기',
     backToPlan: '계획으로 돌아가기',
+    switchConfirm:
+      '"{current}"에서 "{next}"로 전환할까요? 현재 세션을 중지하고 새 계획을 시작합니다.',
+  },
+
+  today: {
+    executionHint: '준비되면 다음 계획을 바로 시작하세요.',
+    activeExecutionHint: '현재 계획에 집중하세요. 실제 시간이 기록되고 있습니다.',
   },
 
   period: {

--- a/apps/desktop/src/shared/utils/serialQueue.ts
+++ b/apps/desktop/src/shared/utils/serialQueue.ts
@@ -1,12 +1,17 @@
-export type AsyncOperation = () => Promise<void>;
+export type AsyncOperation<T = void> = () => Promise<T>;
 
-// (role: serialized async mutation queue, type: (AsyncOperation)=>Promise<void>)
-export function createSerialQueue(): (operation: AsyncOperation) => Promise<void> {
+// (role: serialized async mutation queue, type: (AsyncOperation<T>)=>Promise<T>)
+export function createSerialQueue<T = void>(): (
+  operation: AsyncOperation<T>,
+) => Promise<T> {
   let queue: Promise<void> = Promise.resolve();
 
   return (operation) => {
     const result = queue.then(operation, operation);
-    queue = result.catch(() => undefined);
+    queue = result.then(
+      () => undefined,
+      () => undefined,
+    );
     return result;
   };
 }

--- a/apps/desktop/tests/serialQueue.test.ts
+++ b/apps/desktop/tests/serialQueue.test.ts
@@ -33,4 +33,17 @@ describe('serial async queue', () => {
     expect(secondObservedState).toEqual(['first']);
     expect(state).toEqual(['first', 'second']);
   });
+
+  test('preserves operation results while continuing after a rejection', async () => {
+    const enqueue = createSerialQueue<number>();
+    const first = enqueue(async () => 1);
+    const rejected = enqueue(async () => {
+      throw new Error('expected failure');
+    });
+    const third = enqueue(async () => 3);
+
+    expect(await first).toBe(1);
+    await expect(rejected).rejects.toThrow('expected failure');
+    expect(await third).toBe(3);
+  });
 });


### PR DESCRIPTION
## Summary

- Reframe Today as the primary execution surface with date context, planned-vs-actual time, and executable plans.
- Show the ActiveTimer only for an active, paused, or finished session and visually recede the plan list during execution.
- Make plan rows compact and execution-focused with planned time, tracked time, completion/running state, and Start/Resume actions.
- Confirm plan switching and serialize timer mutations to preserve the one-running-session rule.
- Keep the new Today copy available in English, Korean, and Japanese.

## Validation

- `bun test`
- `bun run lint`
- `bun run build`
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test --workspace`

Closes #13