### PR TITLE
feat(desktop): support date-specific plan adjustments

### DIFF
--- a/apps/desktop/src-tauri/src/core_commands.rs
+++ b/apps/desktop/src-tauri/src/core_commands.rs
@@ -132,6 +132,15 @@ pub struct ScheduleSlotsOutput {
     plans: Vec<PlanOutput>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VirtualPlanRequest {
+    tasks: Vec<TaskInput>,
+    completions: Vec<CompletionInput>,
+    task_id: String,
+    date_ymd: String,
+}
+
 #[tauri::command]
 pub fn core_visible_schedule(request: ScheduleRequest) -> Result<Vec<ScheduleSlotsOutput>, String> {
     let start = parse_date(&request.week_start_ymd)?;
@@ -188,6 +197,31 @@ pub fn core_visible_schedule(request: ScheduleRequest) -> Result<Vec<ScheduleSlo
             })
         })
         .collect()
+}
+
+#[tauri::command]
+pub fn core_virtual_plan_exists(request: VirtualPlanRequest) -> Result<bool, String> {
+    let task = request
+        .tasks
+        .iter()
+        .find(|task| task.id == request.task_id)
+        .ok_or_else(|| "task not found".to_owned())?;
+    let routine = routine_from_task(task)?;
+    let completions = request
+        .completions
+        .iter()
+        .map(completion_from_input)
+        .collect::<Result<Vec<_>, _>>()?;
+    let target = RoutinePlanTarget {
+        routine: &routine,
+        created_local_date: parse_date(&task.created_local_date)?,
+    };
+
+    Ok(frilday_core::has_virtual_plan_on_date(
+        target,
+        &completions,
+        parse_date(&request.date_ymd)?,
+    ))
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/apps/desktop/src-tauri/src/core_commands.rs
+++ b/apps/desktop/src-tauri/src/core_commands.rs
@@ -863,12 +863,8 @@ fn plan_to_output(plan: &Plan) -> PlanOutput {
 
 fn session_from_input(input: &TimeEntryInput) -> Result<Session, String> {
     let started_at = Timestamp::from_unix_millis(input.started_at_millis);
-    let ended_at = input
-        .ended_at_millis
-        .map(|millis| Timestamp::from_unix_millis(millis));
-    let paused_at = input
-        .paused_at_millis
-        .map(|millis| Timestamp::from_unix_millis(millis));
+    let ended_at = input.ended_at_millis.map(Timestamp::from_unix_millis);
+    let paused_at = input.paused_at_millis.map(Timestamp::from_unix_millis);
     let active_started_at = input
         .active_started_at_millis
         .or_else(|| (ended_at.is_none() && paused_at.is_none()).then_some(input.started_at_millis))

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -27,6 +27,7 @@ pub fn run() {
             persistence::get_migration_marker,
             persistence::set_migration_marker,
             core_commands::core_visible_schedule,
+            core_commands::core_virtual_plan_exists,
             core_commands::core_toggle_completion,
             core_commands::core_statistics,
             core_commands::core_time_totals,

--- a/apps/desktop/src-tauri/src/persistence.rs
+++ b/apps/desktop/src-tauri/src/persistence.rs
@@ -1532,7 +1532,7 @@ mod tests {
             let data = sample_data();
 
             let result = import_app_data(&pool, &data).await.unwrap();
-            assert_eq!(result.imported, true);
+            assert!(result.imported);
             assert_eq!(load_app_data_from_pool(&pool).await.unwrap(), data);
         });
     }
@@ -1607,8 +1607,8 @@ mod tests {
             assert_eq!(migration_marker(&pool).await.unwrap().as_deref(), Some("1"));
 
             let second = import_app_data(&pool, &data).await.unwrap();
-            assert_eq!(second.imported, false);
-            assert_eq!(second.skipped_existing_data, false);
+            assert!(!second.imported);
+            assert!(!second.skipped_existing_data);
             let mut reloaded = load_app_data_from_pool(&pool).await.unwrap();
             normalize_loaded_order(&mut reloaded);
             assert_eq!(reloaded, expected);
@@ -1623,7 +1623,7 @@ mod tests {
 
             import_app_data(&pool, &data).await.unwrap();
             let second = import_app_data(&pool, &data).await.unwrap();
-            assert_eq!(second.imported, false);
+            assert!(!second.imported);
 
             let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM tasks")
                 .fetch_one(&pool)
@@ -1655,7 +1655,7 @@ mod tests {
             transaction.commit().await.unwrap();
 
             let result = import_app_data(&pool, &sample_data()).await.unwrap();
-            assert_eq!(result.skipped_existing_data, true);
+            assert!(result.skipped_existing_data);
             let loaded = load_app_data_from_pool(&pool).await.unwrap();
             assert_eq!(loaded.tasks.len(), 2);
             assert!(loaded.tasks.iter().any(|task| task.id == "existing"));

--- a/apps/desktop/src/app/App.tsx
+++ b/apps/desktop/src/app/App.tsx
@@ -162,10 +162,17 @@ export default function App() {
                 onSetPlanDuration={m.setPlanDurationOverride}
                 onSkipPlan={m.skipPlan}
                 onRestorePlan={m.restorePlan}
+                onMovePlan={m.movePlan}
+                dailyCapacityMinutes={m.dailyPlanningCapacityMinutes}
               />
             )}
 
-            {m.tab === 'settings' && <SettingsPage />}
+            {m.tab === 'settings' && (
+              <SettingsPage
+                dailyCapacityMinutes={m.dailyPlanningCapacityMinutes}
+                onSetDailyCapacity={m.setDailyPlanningCapacity}
+              />
+            )}
           </main>
 
           <footer className="mt-10 border-t border-zinc-800 pt-4 text-xs leading-relaxed text-zinc-500">

--- a/apps/desktop/src/app/hooks/useAppModel.ts
+++ b/apps/desktop/src/app/hooks/useAppModel.ts
@@ -9,6 +9,12 @@ import { useLocale } from '../../i18n/useLocale';
 import { getNotifier } from '../di/notifierDI';
 import { getDailyMemoText } from '../../domain/memo';
 import {
+  DEFAULT_DAILY_CAPACITY_MINUTES,
+  MAX_DAILY_CAPACITY_MINUTES,
+  MIN_DAILY_CAPACITY_MINUTES,
+} from '../../domain/schedule/weeklyTimeBudget';
+import { platformSettings } from '../../infrastructure/platform';
+import {
   getCoreStatistics,
   getCoreTimeTotals,
   getRunningTaskIdWithCore,
@@ -43,6 +49,26 @@ const EMPTY_TIME_TOTALS: CoreTimeTotals = {
   byTask: [],
 };
 
+const DAILY_CAPACITY_SETTING_KEY = 'settings.planning.dailyCapacityMinutes';
+
+function parseDailyCapacity(value: unknown): number {
+  return Number.isInteger(value) &&
+    (value as number) >= MIN_DAILY_CAPACITY_MINUTES &&
+    (value as number) <= MAX_DAILY_CAPACITY_MINUTES
+    ? (value as number)
+    : DEFAULT_DAILY_CAPACITY_MINUTES;
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  try {
+    return JSON.stringify(error) || 'Unknown error';
+  } catch {
+    return 'Unknown error';
+  }
+}
+
 function monthStartYmd(ymd: string): string {
   return `${ymd.slice(0, 7)}-01`;
 }
@@ -67,6 +93,7 @@ export function useAppModel() {
     setPlanDurationOverride,
     skipPlan,
     restorePlan,
+    movePlan,
     setDailyMemo,
     startTimer,
     pauseTimer,
@@ -117,6 +144,24 @@ export function useAppModel() {
   const [statistics, setStatistics] = useState<CoreStatistics>(EMPTY_STATS);
   const [timeTotals, setTimeTotals] =
     useState<CoreTimeTotals>(EMPTY_TIME_TOTALS);
+  const [dailyPlanningCapacityMinutes, setDailyPlanningCapacityMinutes] =
+    useState(DEFAULT_DAILY_CAPACITY_MINUTES);
+
+  useEffect(() => {
+    let current = true;
+    void platformSettings
+      .get<number>(DAILY_CAPACITY_SETTING_KEY, DEFAULT_DAILY_CAPACITY_MINUTES)
+      .then((value) => {
+        if (current) setDailyPlanningCapacityMinutes(parseDailyCapacity(value));
+      })
+      .catch(() => {
+        // Keep the transparent default when settings are unavailable.
+      });
+
+    return () => {
+      current = false;
+    };
+  }, []);
 
   const openTimerEntry = useMemo(
     () => timeEntries.find((entry) => entry.endedAt == null) ?? null,
@@ -354,6 +399,25 @@ export function useAppModel() {
   const setError = (msg: string) =>
     useFrilDayStore.setState({ errorMsg: msg });
 
+  const setDailyPlanningCapacity = (minutes: number): boolean => {
+    if (
+      !Number.isInteger(minutes) ||
+      minutes < MIN_DAILY_CAPACITY_MINUTES ||
+      minutes > MAX_DAILY_CAPACITY_MINUTES
+    ) {
+      setError('Daily planning capacity must be a whole number from 1 to 1440 minutes.');
+      return false;
+    }
+
+    const previous = dailyPlanningCapacityMinutes;
+    setDailyPlanningCapacityMinutes(minutes);
+    void platformSettings.set(DAILY_CAPACITY_SETTING_KEY, minutes).catch((error) => {
+      setDailyPlanningCapacityMinutes(previous);
+      setError(`Failed to save daily planning capacity. ${formatError(error)}`);
+    });
+    return true;
+  };
+
   // Handlers
   const handleCreate = (input: CreateTaskInput) => {
     const created = createTask(input);
@@ -568,6 +632,7 @@ export function useAppModel() {
     todayStats: statistics.today,
     periodStats: statistics,
     todayTimeTotals: timeTotals,
+    dailyPlanningCapacityMinutes,
     taskDayStates,
     todayTasks,
     manageTasks,
@@ -575,6 +640,8 @@ export function useAppModel() {
     setPlanDurationOverride,
     skipPlan,
     restorePlan,
+    movePlan,
+    setDailyPlanningCapacity,
 
     // actions
     clearError,

--- a/apps/desktop/src/app/pages/SchedulePage.tsx
+++ b/apps/desktop/src/app/pages/SchedulePage.tsx
@@ -22,12 +22,21 @@ import { LocaleContext } from '../../i18n/context';
 type PlanMutation = (input: {
   taskId: string;
   date: string;
+  planId?: string;
   durationMinutes: number | null;
 }) => boolean | void;
 
 type PlanDateMutation = (input: {
   taskId: string;
   date: string;
+  planId?: string;
+}) => boolean | void;
+
+type PlanMoveMutation = (input: {
+  taskId: string;
+  planId: string;
+  fromDate: string;
+  destinationDate: string;
 }) => boolean | void;
 
 function formatDuration(
@@ -63,12 +72,23 @@ function PlanAdjustment(props: {
   onSetPlanDuration?: PlanMutation;
   onSkipPlan?: PlanDateMutation;
   onRestorePlan?: PlanDateMutation;
+  onMovePlan?: PlanMoveMutation;
+  todayYmd: string;
 }) {
   const { t } = useContext(LocaleContext);
-  const { item, onClose, onSetPlanDuration, onSkipPlan, onRestorePlan } = props;
+  const {
+    item,
+    onClose,
+    onSetPlanDuration,
+    onSkipPlan,
+    onRestorePlan,
+    onMovePlan,
+    todayYmd,
+  } = props;
   const [draft, setDraft] = useState(
     String(item.plan.plannedDurationMinutes),
   );
+  const [moveDraft, setMoveDraft] = useState(item.dateYmd);
   const [validationError, setValidationError] = useState<string | null>(null);
   const isSkipped = item.plan.status === 'skipped';
   const isMoved = item.plan.status === 'moved';
@@ -91,6 +111,7 @@ function PlanAdjustment(props: {
         onSetPlanDuration({
           taskId: item.task.id,
           date: item.dateYmd,
+          planId: item.plan.id,
           durationMinutes,
         }),
       )
@@ -103,7 +124,11 @@ function PlanAdjustment(props: {
     if (
       onRestorePlan &&
       mutationSucceeded(
-        onRestorePlan({ taskId: item.task.id, date: item.dateYmd }),
+        onRestorePlan({
+          taskId: item.task.id,
+          date: item.dateYmd,
+          planId: item.plan.id,
+        }),
       )
     ) {
       onClose();
@@ -114,6 +139,23 @@ function PlanAdjustment(props: {
     if (
       onSkipPlan &&
       mutationSucceeded(onSkipPlan({ taskId: item.task.id, date: item.dateYmd }))
+    ) {
+      onClose();
+    }
+  };
+
+  const move = () => {
+    if (!onMovePlan || !moveDraft) return;
+    setValidationError(null);
+    if (
+      mutationSucceeded(
+        onMovePlan({
+          taskId: item.task.id,
+          planId: item.plan.id,
+          fromDate: item.plan.date,
+          destinationDate: moveDraft,
+        }),
+      )
     ) {
       onClose();
     }
@@ -139,9 +181,7 @@ function PlanAdjustment(props: {
         </button>
       </div>
 
-      {isMoved ? (
-        <p className="mt-3 text-xs text-zinc-400">{t('schedule.movedPlanHint')}</p>
-      ) : isSkipped ? (
+      {isSkipped ? (
         <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
           <span className="text-xs text-amber-200">{t('schedule.allSkipped')}</span>
           {onRestorePlan && (
@@ -155,6 +195,11 @@ function PlanAdjustment(props: {
         </div>
       ) : (
         <>
+          {isMoved && (
+            <p className="mt-3 text-xs text-sky-200/80">
+              {t('schedule.movedPlanHint')}
+            </p>
+          )}
           <div className="mt-3 flex flex-wrap items-end gap-2">
             <label className="flex flex-col gap-1 text-[11px] text-zinc-500">
               {t('task.planned')}
@@ -201,7 +246,7 @@ function PlanAdjustment(props: {
                 {t('schedule.restoreRoutinePlan')}
               </button>
             )}
-            {onSkipPlan && (
+            {!isMoved && onSkipPlan && (
               <button
                 type="button"
                 onClick={skip}
@@ -210,6 +255,31 @@ function PlanAdjustment(props: {
               </button>
             )}
           </div>
+
+          {onMovePlan && (
+            <div className="mt-3 flex flex-wrap items-end gap-2 border-t border-zinc-800 pt-3">
+              <label className="flex flex-col gap-1 text-[11px] text-zinc-500">
+                {t('schedule.moveTo')}
+                <input
+                  type="date"
+                  min={todayYmd}
+                  value={moveDraft}
+                  onChange={(event) => {
+                    setMoveDraft(event.target.value);
+                    setValidationError(null);
+                  }}
+                  className="rounded-lg border border-zinc-700 bg-zinc-900 px-2 py-1.5 text-xs text-zinc-100 outline-none focus:border-sky-300/60"
+                  aria-label={t('schedule.moveTo')}
+                />
+              </label>
+              <button
+                type="button"
+                onClick={move}
+                className="rounded-lg border border-sky-300/30 bg-sky-300/10 px-2.5 py-1.5 text-xs text-sky-100 hover:bg-sky-300/20">
+                {t('schedule.movePlan')}
+              </button>
+            </div>
+          )}
         </>
       )}
     </div>
@@ -224,6 +294,7 @@ function WeeklyLoadOverview(props: {
   const peakDayMinutes = Math.max(0, ...days.map((day) => day.plannedMinutes));
   const maxDailyMinutes = Math.max(1, peakDayMinutes);
   const weekTotal = totalPlannedMinutes(days);
+  const dailyCapacityMinutes = days[0]?.capacityMinutes ?? 0;
   const activePlanCount = days.reduce(
     (total, day) =>
       total + day.plans.filter((item) => item.plan.executable).length,
@@ -262,6 +333,11 @@ function WeeklyLoadOverview(props: {
             })}
           </span>
         </div>
+        <p className="mt-1 text-[11px] text-zinc-600">
+          {t('schedule.capacity', {
+            duration: formatDuration(dailyCapacityMinutes, t),
+          })}
+        </p>
         <div className="mt-3 grid grid-cols-7 items-end gap-1.5 sm:gap-2">
           {days.map((day) => {
             const height =
@@ -304,6 +380,7 @@ function DayBudgetCard(props: {
   onSetPlanDuration?: PlanMutation;
   onSkipPlan?: PlanDateMutation;
   onRestorePlan?: PlanDateMutation;
+  onMovePlan?: PlanMoveMutation;
 }) {
   const {
     day,
@@ -313,6 +390,7 @@ function DayBudgetCard(props: {
     onSetPlanDuration,
     onSkipPlan,
     onRestorePlan,
+    onMovePlan,
   } = props;
   const [adjustingKey, setAdjustingKey] = useState<string | null>(null);
   const skippedCount = day.plans.filter((item) => !item.plan.executable).length;
@@ -352,7 +430,10 @@ function DayBudgetCard(props: {
 
       {day.overloaded && (
         <div className="mt-3 rounded-lg border border-amber-300/20 bg-amber-300/10 px-2 py-1.5 text-xs text-amber-100">
-          {t('schedule.highLoad')}
+          {t('schedule.highLoad', {
+            planned: formatDuration(day.plannedMinutes, t),
+            capacity: formatDuration(day.capacityMinutes, t),
+          })}
         </div>
       )}
 
@@ -451,9 +532,8 @@ function DayBudgetCard(props: {
                         {t('schedule.routine')}
                       </button>
                     )}
-                    {!isMoved &&
-                      canAdjustDate &&
-                      (onSetPlanDuration || onSkipPlan || onRestorePlan) && (
+                    {canAdjustDate &&
+                      (onSetPlanDuration || onSkipPlan || onRestorePlan || onMovePlan) && (
                         <button
                           type="button"
                           onClick={() =>
@@ -465,9 +545,8 @@ function DayBudgetCard(props: {
                           {t('schedule.adjustPlan')}
                         </button>
                       )}
-                    {!isMoved &&
-                      !canAdjustDate &&
-                      (onSetPlanDuration || onSkipPlan || onRestorePlan) && (
+                    {!canAdjustDate &&
+                      (onSetPlanDuration || onSkipPlan || onRestorePlan || onMovePlan) && (
                         <span className="rounded-lg border border-zinc-800 px-2 py-1 text-[11px] text-zinc-600">
                           {t('schedule.pastReadOnly')}
                         </span>
@@ -475,13 +554,15 @@ function DayBudgetCard(props: {
                   </div>
                 </div>
 
-                {isAdjusting && canAdjustDate && !isMoved && (
+                {isAdjusting && canAdjustDate && (
                   <PlanAdjustment
                     item={item}
+                    todayYmd={todayYmd}
                     onClose={() => setAdjustingKey(null)}
                     onSetPlanDuration={onSetPlanDuration}
                     onSkipPlan={onSkipPlan}
                     onRestorePlan={onRestorePlan}
+                    onMovePlan={onMovePlan}
                   />
                 )}
               </article>
@@ -504,6 +585,8 @@ export function SchedulePage(props: {
   onSetPlanDuration?: PlanMutation;
   onSkipPlan?: PlanDateMutation;
   onRestorePlan?: PlanDateMutation;
+  onMovePlan?: PlanMoveMutation;
+  dailyCapacityMinutes?: number;
 }) {
   const { t } = useContext(LocaleContext);
   const {
@@ -517,6 +600,8 @@ export function SchedulePage(props: {
     onSetPlanDuration,
     onSkipPlan,
     onRestorePlan,
+    onMovePlan,
+    dailyCapacityMinutes,
   } = props;
 
   const currentWeekStartYmd = useMemo(
@@ -535,7 +620,6 @@ export function SchedulePage(props: {
     () => normalizeWeekStart(displayWeekStartYmd),
     [displayWeekStartYmd],
   );
-  const canGoNext = normalizedWeekStartYmd < currentWeekStartYmd;
   const [scheduleSlots, setScheduleSlots] = useState<CoreScheduleSlot[]>([]);
 
   useEffect(() => {
@@ -574,8 +658,16 @@ export function SchedulePage(props: {
         weekDates,
         completions,
         getMemoText,
+        dailyCapacityMinutes,
       }),
-    [tasks, scheduleSlots, weekDates, completions, getMemoText],
+    [
+      tasks,
+      scheduleSlots,
+      weekDates,
+      completions,
+      getMemoText,
+      dailyCapacityMinutes,
+    ],
   );
   const weekEndYmd = weekDates[6] ?? normalizedWeekStartYmd;
 
@@ -610,14 +702,10 @@ export function SchedulePage(props: {
             </button>
             <button
               type="button"
-              onClick={() => {
-                if (!canGoNext) return;
-                setDisplayWeekStartYmd((previous) =>
-                  shiftWeekStart(previous, 7),
-                );
-              }}
-              disabled={!canGoNext}
-              className="rounded-xl border border-zinc-800 bg-zinc-900/40 px-3 py-1.5 text-xs text-zinc-200 hover:bg-zinc-900/70 disabled:cursor-not-allowed disabled:opacity-50">
+              onClick={() =>
+                setDisplayWeekStartYmd((previous) => shiftWeekStart(previous, 7))
+              }
+              className="rounded-xl border border-zinc-800 bg-zinc-900/40 px-3 py-1.5 text-xs text-zinc-200 hover:bg-zinc-900/70">
               {t('schedule.nextWeek')}
             </button>
           </div>
@@ -645,6 +733,7 @@ export function SchedulePage(props: {
             onSetPlanDuration={onSetPlanDuration}
             onSkipPlan={onSkipPlan}
             onRestorePlan={onRestorePlan}
+            onMovePlan={onMovePlan}
           />
         ))}
       </div>

--- a/apps/desktop/src/app/pages/SchedulePage.tsx
+++ b/apps/desktop/src/app/pages/SchedulePage.tsx
@@ -37,7 +37,7 @@ type PlanMoveMutation = (input: {
   planId: string;
   fromDate: string;
   destinationDate: string;
-}) => boolean | void;
+}) => boolean | void | Promise<boolean | void>;
 
 function formatDuration(
   minutes: number,
@@ -144,19 +144,16 @@ function PlanAdjustment(props: {
     }
   };
 
-  const move = () => {
+  const move = async () => {
     if (!onMovePlan || !moveDraft) return;
     setValidationError(null);
-    if (
-      mutationSucceeded(
-        onMovePlan({
-          taskId: item.task.id,
-          planId: item.plan.id,
-          fromDate: item.plan.date,
-          destinationDate: moveDraft,
-        }),
-      )
-    ) {
+    const result = await onMovePlan({
+      taskId: item.task.id,
+      planId: item.plan.id,
+      fromDate: item.plan.date,
+      destinationDate: moveDraft,
+    });
+    if (mutationSucceeded(result)) {
       onClose();
     }
   };

--- a/apps/desktop/src/app/pages/SettingsPage.tsx
+++ b/apps/desktop/src/app/pages/SettingsPage.tsx
@@ -1,13 +1,38 @@
-import { useContext } from 'react';
+import { useContext, useRef, useState } from 'react';
 import type { Locale } from '../../i18n';
 import { LocaleContext } from '../../i18n/context';
+import {
+  MAX_DAILY_CAPACITY_MINUTES,
+  MIN_DAILY_CAPACITY_MINUTES,
+} from '../../domain/schedule/weeklyTimeBudget';
 
-export function SettingsPage() {
+export function SettingsPage(props: {
+  dailyCapacityMinutes: number;
+  onSetDailyCapacity: (minutes: number) => boolean;
+}) {
   const { locale, setLocale, t } = useContext(LocaleContext);
+  const capacityInputRef = useRef<HTMLInputElement>(null);
+  const [capacityError, setCapacityError] = useState<string | null>(null);
 
   // (role: change handler, type: (e: React.ChangeEvent<HTMLSelectElement>)=>void)
   const onChangeLocale = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setLocale(e.target.value as Locale);
+  };
+
+  const saveCapacity = () => {
+    const minutes = Number(capacityInputRef.current?.value.trim() ?? '');
+    if (
+      !Number.isInteger(minutes) ||
+      minutes < MIN_DAILY_CAPACITY_MINUTES ||
+      minutes > MAX_DAILY_CAPACITY_MINUTES
+    ) {
+      setCapacityError(t('settings.capacity.validation'));
+      return;
+    }
+
+    if (props.onSetDailyCapacity(minutes)) {
+      setCapacityError(null);
+    }
   };
 
   return (
@@ -36,6 +61,52 @@ export function SettingsPage() {
             </select>
           </div>
         </div>
+      </section>
+
+      <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="min-w-0">
+            <h2 className="text-base font-semibold text-zinc-100">
+              {t('settings.capacity.title')}
+            </h2>
+            <p className="mt-1 text-sm text-zinc-400">
+              {t('settings.capacity.desc')}
+            </p>
+          </div>
+
+          <div className="flex shrink-0 items-end gap-2">
+            <label className="flex flex-col gap-1 text-xs text-zinc-500">
+              <span>{t('settings.capacity.label')}</span>
+              <input
+                key={props.dailyCapacityMinutes}
+                type="number"
+                min={MIN_DAILY_CAPACITY_MINUTES}
+                max={MAX_DAILY_CAPACITY_MINUTES}
+                defaultValue={props.dailyCapacityMinutes}
+                ref={capacityInputRef}
+                onChange={() => {
+                  setCapacityError(null);
+                }}
+                className="h-10 w-28 rounded-xl border border-zinc-800 bg-zinc-950/40 px-3 text-right text-sm text-zinc-100 outline-none focus:ring-2 focus:ring-zinc-700"
+                aria-label={t('settings.capacity.label')}
+              />
+            </label>
+            <button
+              type="button"
+              onClick={saveCapacity}
+              className="h-10 rounded-xl border border-emerald-300/30 bg-emerald-300/10 px-3 text-sm text-emerald-100 hover:bg-emerald-300/20">
+              {t('common.save')}
+            </button>
+          </div>
+        </div>
+        <p className="mt-2 text-xs text-zinc-500">
+          {t('settings.capacity.range')}
+        </p>
+        {capacityError && (
+          <p className="mt-2 text-xs text-rose-300" role="alert">
+            {capacityError}
+          </p>
+        )}
       </section>
 
     </div>

--- a/apps/desktop/src/app/store/useFrilDayStore.ts
+++ b/apps/desktop/src/app/store/useFrilDayStore.ts
@@ -18,7 +18,7 @@ import {
   setCompletion,
   setTaskActive,
 } from '../../infrastructure/storage';
-import { toYmd } from '../../shared/utils/date';
+import { isValidYmd, toYmd } from '../../shared/utils/date';
 import {
   createSerialQueue,
   type AsyncOperation,
@@ -93,10 +93,17 @@ interface FrilDayState {
   setPlanDurationOverride: (input: {
     taskId: string;
     date: string;
+    planId?: string;
     durationMinutes: number | null;
   }) => boolean;
   skipPlan: (input: { taskId: string; date: string }) => boolean;
-  restorePlan: (input: { taskId: string; date: string }) => boolean;
+  restorePlan: (input: { taskId: string; date: string; planId?: string }) => boolean;
+  movePlan: (input: {
+    taskId: string;
+    planId?: string;
+    fromDate: string;
+    destinationDate: string;
+  }) => boolean;
   setDailyMemo: (input: { taskId: string; date: string; text: string }) => void;
   startTimer: (input: { taskId: string; today: Date }) => Promise<TimerMutationResult>;
   pauseTimer: (input: { taskId: string; today: Date }) => Promise<TimerMutationResult>;
@@ -151,7 +158,7 @@ function hasPlanHistory(
   state: Pick<FrilDayState, 'timeEntries' | 'completions'>,
   planId: string,
   taskId: string,
-  date: string,
+  ...dates: string[]
 ): boolean {
   return (
     state.timeEntries.some((entry) => entry.planId === planId) ||
@@ -160,8 +167,10 @@ function hasPlanHistory(
         completion.taskId === taskId &&
         (completion.planId === planId ||
           (completion.planId == null &&
-            completion.date === date &&
-            routinePlanId(taskId, date) === planId)),
+            dates.some(
+              (date) =>
+                completion.date === date && routinePlanId(taskId, date) === planId,
+            ))),
     )
   );
 }
@@ -236,7 +245,7 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
   setFilter: (filter) => set({ filter }),
   clearError: () => set({ errorMsg: '' }),
 
-  setPlanDurationOverride: ({ taskId, date, durationMinutes }) => {
+  setPlanDurationOverride: ({ taskId, date, planId, durationMinutes }) => {
     const task = get().tasks.find((candidate) => candidate.id === taskId);
     if (!task) {
       set({ errorMsg: 'Task not found.' });
@@ -250,12 +259,28 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
       return false;
     }
 
-    const id = routinePlanId(taskId, date);
+    const id = planId ?? routinePlanId(taskId, date);
     const current = get().plans.find((plan) => plan.id === id);
-    const hasHistory = hasPlanHistory(get(), id, taskId, date);
+    const sourceDate = current?.date ?? date;
+    const hasHistory = hasPlanHistory(
+      get(),
+      id,
+      taskId,
+      sourceDate,
+      ...(current?.movedToYmd ? [current.movedToYmd] : []),
+    );
     if (hasHistory) {
       set({ errorMsg: 'Historical plans cannot be changed.' });
       return false;
+    }
+    if (durationMinutes == null && current?.status === 'moved') {
+      const nextPlan = { ...current, durationOverrideMinutes: null };
+      set({
+        plans: [nextPlan, ...get().plans.filter((plan) => plan.id !== id)],
+        errorMsg: '',
+      });
+      persist(() => savePlan(nextPlan), 'Failed to restore plan.');
+      return true;
     }
     if (durationMinutes == null && current) {
       set({ plans: get().plans.filter((plan) => plan.id !== id), errorMsg: '' });
@@ -263,14 +288,20 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
       return true;
     }
     if (durationMinutes == null) return true;
-    const nextPlan = createRoutinePlan({
-      routineId: taskId,
-      date,
-      baselineDurationMinutes: current?.baselineDurationMinutes ?? task.durationMinutes,
-      durationOverrideMinutes: durationMinutes,
-      status: current?.status === 'skipped' ? 'planned' : current?.status,
-      movedToYmd: current?.movedToYmd,
-    });
+    const nextPlan = current
+      ? {
+          ...current,
+          durationOverrideMinutes: durationMinutes,
+          ...(current.status === 'skipped'
+            ? { status: 'planned' as const, movedToYmd: null }
+            : {}),
+        }
+      : createRoutinePlan({
+          routineId: taskId,
+          date,
+          baselineDurationMinutes: task.durationMinutes,
+          durationOverrideMinutes: durationMinutes,
+        });
     const nextPlans = [
       nextPlan,
       ...get().plans.filter((plan) => plan.id !== nextPlan.id),
@@ -308,19 +339,110 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
     return true;
   },
 
-  restorePlan: ({ taskId, date }) => {
-    const id = routinePlanId(taskId, date);
+  restorePlan: ({ taskId, date, planId }) => {
+    const id = planId ?? routinePlanId(taskId, date);
     const current = get().plans.find((plan) => plan.id === id);
     if (!current) return true;
 
-    const hasHistory = hasPlanHistory(get(), id, taskId, date);
+    const hasHistory = hasPlanHistory(
+      get(),
+      id,
+      taskId,
+      current.date,
+      ...(current.movedToYmd ? [current.movedToYmd] : []),
+    );
     if (hasHistory) {
       set({ errorMsg: 'Historical plans cannot be changed.' });
       return false;
     }
 
+    if (current.status === 'moved') {
+      const nextPlan = { ...current, durationOverrideMinutes: null };
+      set({
+        plans: [nextPlan, ...get().plans.filter((plan) => plan.id !== id)],
+        errorMsg: '',
+      });
+      persist(() => savePlan(nextPlan), 'Failed to restore plan.');
+      return true;
+    }
+
     set({ plans: get().plans.filter((plan) => plan.id !== id), errorMsg: '' });
     persist(() => deletePlan(id), 'Failed to restore plan.');
+    return true;
+  },
+
+  movePlan: ({ taskId, planId, fromDate, destinationDate }) => {
+    const task = get().tasks.find((candidate) => candidate.id === taskId);
+    if (!task) {
+      set({ errorMsg: 'Task not found.' });
+      return false;
+    }
+    if (!isValidYmd(fromDate) || !isValidYmd(destinationDate)) {
+      set({ errorMsg: 'Enter a valid calendar date.' });
+      return false;
+    }
+    if (fromDate === destinationDate) {
+      set({ errorMsg: 'Choose a different destination date.' });
+      return false;
+    }
+
+    const sourceId = routinePlanId(taskId, fromDate);
+    const current =
+      (planId != null ? get().plans.find((plan) => plan.id === planId) : undefined) ??
+      get().plans.find((plan) => plan.id === sourceId);
+    const sourcePlan =
+      current ??
+      createRoutinePlan({
+        routineId: taskId,
+        date: fromDate,
+        baselineDurationMinutes: task.durationMinutes,
+      });
+
+    if (sourcePlan.routineId !== taskId || sourcePlan.date !== fromDate) {
+      set({ errorMsg: 'The selected plan does not belong to this routine.' });
+      return false;
+    }
+
+    if (sourcePlan.status === 'skipped') {
+      set({ errorMsg: 'Skipped plans cannot be moved.' });
+      return false;
+    }
+    if (
+      hasPlanHistory(
+        get(),
+        sourcePlan.id,
+        taskId,
+        sourcePlan.date,
+        ...(sourcePlan.movedToYmd ? [sourcePlan.movedToYmd] : []),
+      )
+    ) {
+      set({ errorMsg: 'Historical plans cannot be changed.' });
+      return false;
+    }
+
+    const conflicts = get().plans.some(
+      (plan) =>
+        plan.id !== sourcePlan.id &&
+        plan.routineId === taskId &&
+        (plan.date === destinationDate || plan.movedToYmd === destinationDate),
+    );
+    if (conflicts) {
+      set({
+        errorMsg: 'This routine already has a plan on the destination date.',
+      });
+      return false;
+    }
+
+    const nextPlan = {
+      ...sourcePlan,
+      status: 'moved' as const,
+      movedToYmd: destinationDate,
+    };
+    set({
+      plans: [nextPlan, ...get().plans.filter((plan) => plan.id !== sourcePlan.id)],
+      errorMsg: '',
+    });
+    persist(() => savePlan(nextPlan), 'Failed to move plan.');
     return true;
   },
 

--- a/apps/desktop/src/app/store/useFrilDayStore.ts
+++ b/apps/desktop/src/app/store/useFrilDayStore.ts
@@ -32,6 +32,7 @@ import { upsertDailyMemo } from '../../domain/memo';
 import { createRoutinePlan, routinePlanId } from '../../domain/plan/plan';
 import {
   getTargetReachedWithCore,
+  hasVirtualPlanOnDateWithCore,
   pauseTimerWithCore,
   resumeTimerWithCore,
   startTimerWithCore,
@@ -103,7 +104,7 @@ interface FrilDayState {
     planId?: string;
     fromDate: string;
     destinationDate: string;
-  }) => boolean;
+  }) => Promise<boolean>;
   setDailyMemo: (input: { taskId: string; date: string; text: string }) => void;
   startTimer: (input: { taskId: string; today: Date }) => Promise<TimerMutationResult>;
   pauseTimer: (input: { taskId: string; today: Date }) => Promise<TimerMutationResult>;
@@ -371,7 +372,7 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
     return true;
   },
 
-  movePlan: ({ taskId, planId, fromDate, destinationDate }) => {
+  movePlan: async ({ taskId, planId, fromDate, destinationDate }) => {
     const task = get().tasks.find((candidate) => candidate.id === taskId);
     if (!task) {
       set({ errorMsg: 'Task not found.' });
@@ -381,11 +382,6 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
       set({ errorMsg: 'Enter a valid calendar date.' });
       return false;
     }
-    if (fromDate === destinationDate) {
-      set({ errorMsg: 'Choose a different destination date.' });
-      return false;
-    }
-
     const sourceId = routinePlanId(taskId, fromDate);
     const current =
       (planId != null ? get().plans.find((plan) => plan.id === planId) : undefined) ??
@@ -420,6 +416,36 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
       return false;
     }
 
+    if (fromDate === destinationDate) {
+      if (sourcePlan.status !== 'moved') {
+        set({ errorMsg: 'Choose a different destination date.' });
+        return false;
+      }
+
+      const restoredPlan = {
+        ...sourcePlan,
+        status: 'planned' as const,
+        movedToYmd: null,
+      };
+      if (restoredPlan.durationOverrideMinutes == null) {
+        set({
+          plans: get().plans.filter((plan) => plan.id !== sourcePlan.id),
+          errorMsg: '',
+        });
+        persist(() => deletePlan(sourcePlan.id), 'Failed to restore plan.');
+      } else {
+        set({
+          plans: [
+            restoredPlan,
+            ...get().plans.filter((plan) => plan.id !== sourcePlan.id),
+          ],
+          errorMsg: '',
+        });
+        persist(() => savePlan(restoredPlan), 'Failed to restore plan.');
+      }
+      return true;
+    }
+
     const conflicts = get().plans.some(
       (plan) =>
         plan.id !== sourcePlan.id &&
@@ -427,6 +453,28 @@ export const useFrilDayStore = create<FrilDayState>((set, get) => ({
         (plan.date === destinationDate || plan.movedToYmd === destinationDate),
     );
     if (conflicts) {
+      set({
+        errorMsg: 'This routine already has a plan on the destination date.',
+      });
+      return false;
+    }
+
+    let hasVirtualDestination = false;
+    try {
+      hasVirtualDestination = await hasVirtualPlanOnDateWithCore({
+        tasks: get().tasks,
+        completions: get().completions,
+        taskId,
+        dateYmd: destinationDate,
+      });
+    } catch (error) {
+      set({
+        errorMsg: `Failed to validate the destination date. ${formatError(error)}`,
+      });
+      return false;
+    }
+
+    if (hasVirtualDestination) {
       set({
         errorMsg: 'This routine already has a plan on the destination date.',
       });

--- a/apps/desktop/src/domain/schedule/weeklyTimeBudget.ts
+++ b/apps/desktop/src/domain/schedule/weeklyTimeBudget.ts
@@ -1,7 +1,13 @@
 import type { Completion, DayOfWeek, Task } from '../../shared/types';
 import { WEEK_ORDER } from './scheduleView';
 
-export const OVERLOADED_DAY_MINUTES = 8 * 60;
+export const DEFAULT_DAILY_CAPACITY_MINUTES = 8 * 60;
+export const MIN_DAILY_CAPACITY_MINUTES = 1;
+export const MAX_DAILY_CAPACITY_MINUTES = 24 * 60;
+
+// Kept as a compatibility alias for callers that used the original fixed
+// threshold before daily capacity became configurable.
+export const OVERLOADED_DAY_MINUTES = DEFAULT_DAILY_CAPACITY_MINUTES;
 
 export type WeeklyPlanProjection = {
   id: string;
@@ -36,6 +42,7 @@ export type WeeklyDayBudget = {
   plannedMinutes: number;
   skippedMinutes: number;
   completedCount: number;
+  capacityMinutes: number;
   overloaded: boolean;
 };
 
@@ -71,10 +78,17 @@ export function buildWeeklyTimeBudget(input: {
   weekDates: readonly string[];
   completions: Completion[];
   getMemoText?: (taskId: string, date: string) => string;
+  dailyCapacityMinutes?: number;
 }): WeeklyDayBudget[] {
   const slotsByTask = new Map(
     input.scheduleSlots.map((slot) => [slot.taskId, slot]),
   );
+  const dailyCapacityMinutes =
+    Number.isInteger(input.dailyCapacityMinutes) &&
+    input.dailyCapacityMinutes! >= MIN_DAILY_CAPACITY_MINUTES &&
+    input.dailyCapacityMinutes! <= MAX_DAILY_CAPACITY_MINUTES
+      ? input.dailyCapacityMinutes!
+      : DEFAULT_DAILY_CAPACITY_MINUTES;
 
   return input.weekDates.slice(0, 7).map((dateYmd, index) => {
     const day = WEEK_ORDER[index] ?? 'Sun';
@@ -131,7 +145,8 @@ export function buildWeeklyTimeBudget(input: {
       plannedMinutes,
       skippedMinutes,
       completedCount: plans.filter((item) => item.completed).length,
-      overloaded: plannedMinutes >= OVERLOADED_DAY_MINUTES,
+      capacityMinutes: dailyCapacityMinutes,
+      overloaded: plannedMinutes > dailyCapacityMinutes,
     };
   });
 }

--- a/apps/desktop/src/features/task/components/TaskList.tsx
+++ b/apps/desktop/src/features/task/components/TaskList.tsx
@@ -28,10 +28,11 @@ interface TaskListProps {
   onSetPlanDuration?: (input: {
     taskId: string;
     date: string;
+    planId?: string;
     durationMinutes: number | null;
   }) => void;
   onSkipPlan?: (input: { taskId: string; date: string }) => void;
-  onRestorePlan?: (input: { taskId: string; date: string }) => void;
+  onRestorePlan?: (input: { taskId: string; date: string; planId?: string }) => void;
   onArchive: (taskId: string) => void;
   onRestore?: (taskId: string) => void;
   onSaveMemo?: (input: { taskId: string; date: string; text: string }) => void;

--- a/apps/desktop/src/features/task/components/TaskListItem.tsx
+++ b/apps/desktop/src/features/task/components/TaskListItem.tsx
@@ -36,10 +36,11 @@ interface TaskListItemProps {
   onSetPlanDuration?: (input: {
     taskId: string;
     date: string;
+    planId?: string;
     durationMinutes: number | null;
   }) => void;
   onSkipPlan?: (input: { taskId: string; date: string }) => void;
-  onRestorePlan?: (input: { taskId: string; date: string }) => void;
+  onRestorePlan?: (input: { taskId: string; date: string; planId?: string }) => void;
   onArchive: (taskId: string) => void; // (role: archive task, type: (string)=>void)
   onRestore?: (taskId: string) => void; // (role: restore handler, type: ((string)=>void) | undefined)
   onStartTimer: (task: Task) => void; // (role: start timer, type: (Task)=>void)
@@ -93,6 +94,7 @@ export function TaskListItem(props: TaskListItemProps) {
   const scheduledToday = taskDayState?.scheduled ?? false;
   const doneToday = taskDayState?.completed ?? false;
   const skippedToday = taskDayState?.planStatus === 'skipped';
+  const movedToday = taskDayState?.planStatus === 'moved';
 
   // (role: safe description string, type: string)
   const description = (task.description ?? '').trim();
@@ -147,6 +149,7 @@ export function TaskListItem(props: TaskListItemProps) {
     onSetPlanDuration({
       taskId: task.id,
       date: todayYmd,
+      planId: taskDayState?.planId ?? undefined,
       durationMinutes: duration,
     });
   };
@@ -417,7 +420,13 @@ export function TaskListItem(props: TaskListItemProps) {
                 {planHasOverride && !skippedToday && onRestorePlan && (
                   <button
                     type="button"
-                    onClick={() => onRestorePlan({ taskId: task.id, date: todayYmd })}
+                    onClick={() =>
+                      onRestorePlan({
+                        taskId: task.id,
+                        date: todayYmd,
+                        planId: taskDayState?.planId ?? undefined,
+                      })
+                    }
                     className="rounded-lg border border-zinc-700 px-2 py-1 text-xs text-zinc-300 hover:bg-zinc-800">
                     {tr('task.restoreRoutinePlan')}
                   </button>
@@ -425,12 +434,18 @@ export function TaskListItem(props: TaskListItemProps) {
                 {skippedToday && onRestorePlan && !open && (
                   <button
                     type="button"
-                    onClick={() => onRestorePlan({ taskId: task.id, date: todayYmd })}
+                    onClick={() =>
+                      onRestorePlan({
+                        taskId: task.id,
+                        date: todayYmd,
+                        planId: taskDayState?.planId ?? undefined,
+                      })
+                    }
                     className="rounded-lg border border-emerald-300/30 bg-emerald-300/10 px-2 py-1 text-xs text-emerald-100 hover:bg-emerald-300/20">
                     {tr('task.restoreRoutinePlan')}
                   </button>
                 )}
-                {onSkipPlan && !skippedToday && !open && (
+                {onSkipPlan && !skippedToday && !movedToday && !open && (
                   <button
                     type="button"
                     onClick={() => onSkipPlan({ taskId: task.id, date: todayYmd })}

--- a/apps/desktop/src/i18n/messages/en.ts
+++ b/apps/desktop/src/i18n/messages/en.ts
@@ -217,9 +217,10 @@ export const en = {
     weekSummary: '{days} planned days · {plans} plans',
     planningHint: 'Plan the week around time budget. Routine defaults stay unchanged.',
     durationHint: 'Durations and skips here apply to this date only. Open Routine for recurring defaults.',
+    capacity: 'Daily capacity: {duration}',
     noPlansForDay: 'No plans for this day.',
     allSkipped: 'All plans skipped',
-    highLoad: 'High planned load (8h or more)',
+    highLoad: 'Over daily capacity: {planned} planned / {capacity} capacity',
     adjustPlan: 'Adjust plan',
     adjustPlanHint: 'Changes apply to this date only.',
     pastReadOnly: 'Past plans are read-only',
@@ -235,6 +236,8 @@ export const en = {
     routine: 'Routine',
     openRoutine: 'Open routine {task}',
     movedPlanHint: 'Moved Plans are adjusted from their original date.',
+    moveTo: 'Move to date',
+    movePlan: 'Move plan',
   },
 
   notify: {
@@ -257,6 +260,13 @@ export const en = {
         ko: 'Korean',
         ja: 'Japanese',
       },
+    },
+    capacity: {
+      title: 'Daily planning capacity',
+      desc: 'Use a transparent daily time budget to spot over-planned days.',
+      label: 'Minutes per day',
+      range: 'Choose from 1 to 1440 minutes. This is advisory and never blocks planning.',
+      validation: 'Capacity must be a whole number from 1 to 1440 minutes.',
     },
     notifications: {
       timerDone: {

--- a/apps/desktop/src/i18n/messages/ja.ts
+++ b/apps/desktop/src/i18n/messages/ja.ts
@@ -215,9 +215,10 @@ export const ja = {
     weekSummary: '予定日 {days}日 · 予定 {plans}件',
     planningHint: '時間予算を中心に週を計画します。ルーティンのデフォルトは変わりません。',
     durationHint: 'ここでの時間変更とスキップはこの日だけに適用されます。繰り返しのデフォルトはルーティンで管理します。',
+    capacity: '1日の予定上限: {duration}',
     noPlansForDay: 'この日の予定はありません。',
     allSkipped: 'すべての予定をスキップしました',
-    highLoad: '予定量が多い日です (8時間以上)',
+    highLoad: '1日の予定上限超過: {planned} / 上限 {capacity}',
     adjustPlan: '予定を調整',
     adjustPlanHint: '変更はこの日だけに適用されます。',
     pastReadOnly: '過去の予定は読み取り専用です',
@@ -233,6 +234,8 @@ export const ja = {
     routine: 'ルーティン',
     openRoutine: '{task} のルーティンを開く',
     movedPlanHint: '移動した予定は元の日付から調整できます。',
+    moveTo: '移動先の日付',
+    movePlan: '予定を移動',
   },
 
   notify: {
@@ -255,6 +258,13 @@ export const ja = {
         ko: '한국어',
         ja: '日本語',
       },
+    },
+    capacity: {
+      title: '1日の予定上限',
+      desc: '透明な時間予算で、予定を入れすぎた日を確認します。',
+      label: '1日の分数',
+      range: '1〜1440分で設定できます。あくまで目安で、計画を妨げません。',
+      validation: '上限は1〜1440分の整数で入力してください。',
     },
     notifications: {
       timerDone: {

--- a/apps/desktop/src/i18n/messages/ko.ts
+++ b/apps/desktop/src/i18n/messages/ko.ts
@@ -214,9 +214,10 @@ export const ko = {
     weekSummary: '계획된 {days}일 · {plans}개 계획',
     planningHint: '시간 예산을 기준으로 한 주를 계획하세요. 루틴 기본값은 바뀌지 않습니다.',
     durationHint: '여기서 바꾼 시간과 건너뛰기는 해당 날짜에만 적용됩니다. 반복 기본값은 루틴에서 관리하세요.',
+    capacity: '일일 계획 용량: {duration}',
     noPlansForDay: '이 날에는 계획이 없습니다.',
     allSkipped: '모든 계획을 건너뛰었습니다',
-    highLoad: '계획량이 많습니다 (8시간 이상)',
+    highLoad: '일일 용량 초과: {planned} 계획 / {capacity} 용량',
     adjustPlan: '계획 조정',
     adjustPlanHint: '변경 사항은 이 날짜에만 적용됩니다.',
     pastReadOnly: '지난 계획은 읽기 전용입니다',
@@ -232,6 +233,8 @@ export const ko = {
     routine: '루틴',
     openRoutine: '{task} 루틴 열기',
     movedPlanHint: '이동된 계획은 원래 날짜에서 조정할 수 있습니다.',
+    moveTo: '이동할 날짜',
+    movePlan: '계획 이동',
   },
 
   notify: {
@@ -254,6 +257,13 @@ export const ko = {
         ko: '한국어',
         ja: '日本語',
       },
+    },
+    capacity: {
+      title: '일일 계획 용량',
+      desc: '투명한 하루 시간 예산으로 과도하게 계획된 날을 확인합니다.',
+      label: '하루 분량(분)',
+      range: '1~1440분으로 설정할 수 있습니다. 참고용 안내이며 계획을 차단하지 않습니다.',
+      validation: '용량은 1~1440분 사이의 정수여야 합니다.',
     },
     notifications: {
       timerDone: {

--- a/apps/desktop/src/infrastructure/tauri/core.ts
+++ b/apps/desktop/src/infrastructure/tauri/core.ts
@@ -205,6 +205,20 @@ export async function getVisibleScheduleSlots(input: {
   });
 }
 
+export async function hasVirtualPlanOnDateWithCore(input: {
+  tasks: Task[];
+  completions: Completion[];
+  taskId: string;
+  dateYmd: string;
+}): Promise<boolean> {
+  return invokeCore<boolean>('core_virtual_plan_exists', {
+    tasks: input.tasks.map(toCoreTask),
+    completions: input.completions.map(toCoreCompletion),
+    taskId: input.taskId,
+    dateYmd: input.dateYmd,
+  });
+}
+
 export async function toggleCompletionWithCore(input: {
   tasks: Task[];
   completions: Completion[];

--- a/apps/desktop/tests/weeklyTimeBudget.test.ts
+++ b/apps/desktop/tests/weeklyTimeBudget.test.ts
@@ -113,6 +113,20 @@ describe('weekly time budget projection', () => {
     expect(totalPlannedMinutes(days)).toBe(0);
   });
 
+  test('uses the configured daily capacity for advisory overload feedback', () => {
+    const days = buildWeeklyTimeBudget({
+      tasks: [task],
+      scheduleSlots: [slot([plan({ plannedDurationMinutes: 61 })])],
+      weekDates,
+      completions: [],
+      dailyCapacityMinutes: 60,
+    });
+
+    expect(days[0]?.capacityMinutes).toBe(60);
+    expect(days[0]?.overloaded).toBe(true);
+    expect(days[1]?.overloaded).toBe(false);
+  });
+
   test('recognises both stable Plan completions and legacy task-date completions', () => {
     const current = plan({ plannedDurationMinutes: 60 });
     const legacy = plan({

--- a/crates/frilday-core/src/lib.rs
+++ b/crates/frilday-core/src/lib.rs
@@ -23,7 +23,7 @@ pub use completion::{
 pub use date::{DateError, LocalDate, Weekday};
 pub use ids::{IdError, PlanId, RoutineId, SessionId};
 pub use plan::{Plan, PlanError, PlanStatus};
-pub use planning::{RoutinePlanTarget, resolve_plan, resolve_plans};
+pub use planning::{RoutinePlanTarget, has_virtual_plan_on_date, resolve_plan, resolve_plans};
 pub use routine::{Routine, RoutineError};
 pub use schedule::{
     CustomSchedule, ScheduleError, ScheduleRule, completed_dates_between, effective_start_on,

--- a/crates/frilday-core/src/plan.rs
+++ b/crates/frilday-core/src/plan.rs
@@ -1,9 +1,11 @@
 use std::fmt;
 
 use crate::{
+    completion::Completion,
     date::LocalDate,
     ids::{PlanId, RoutineId},
     routine::Routine,
+    session::Session,
     time::PlannedDuration,
 };
 
@@ -159,6 +161,23 @@ impl Plan {
 
     pub const fn is_executable(&self) -> bool {
         !matches!(self.status, PlanStatus::Skipped)
+    }
+
+    /// A Plan with actual-work or completion history is an immutable
+    /// historical snapshot. Adapters can use this before applying a
+    /// date-specific adjustment so recorded actuals are never rewritten.
+    pub fn has_history(&self, completions: &[Completion], sessions: &[Session]) -> bool {
+        completions.iter().any(|completion| {
+            completion.plan_id() == Some(&self.id)
+                || self.routine_id.as_ref().is_some_and(|routine_id| {
+                    completion.matches_routine_on(routine_id, self.date)
+                        || completion.matches_routine_on(routine_id, self.effective_date())
+                })
+        }) || sessions.iter().any(|session| {
+            session.plan_id() == Some(&self.id)
+                || (session.routine_id() == self.routine_id.as_ref()
+                    && (session.date() == self.date || session.date() == self.effective_date()))
+        })
     }
 
     pub fn set_duration_override(&mut self, duration: Option<PlannedDuration>) {

--- a/crates/frilday-core/src/planning.rs
+++ b/crates/frilday-core/src/planning.rs
@@ -46,6 +46,26 @@ pub fn resolve_plan(
     })
 }
 
+/// Check whether a Routine would contribute a virtual Plan on a date.
+///
+/// The desktop adapter uses this alongside persisted Plan records when it
+/// validates a move destination. Keeping the recurrence and occurrence-limit
+/// rules here avoids duplicating schedule projection logic in the UI layer.
+pub fn has_virtual_plan_on_date(
+    target: RoutinePlanTarget<'_>,
+    completions: &[Completion],
+    date: LocalDate,
+) -> bool {
+    visible_dates_between(
+        target.routine,
+        date,
+        date,
+        target.created_local_date,
+        completions,
+    )
+    .contains(&date)
+}
+
 /// Resolve all Plans in an inclusive range without producing duplicates.
 /// Persisted records are included by their effective date so moved Plans are
 /// still visible at their destination, while skipped Plans remain attached to
@@ -296,6 +316,21 @@ mod tests {
 
         assert_eq!(plans.len(), 1);
         assert_eq!(plans[0].effective_date(), destination);
+    }
+
+    #[test]
+    fn naturally_scheduled_destination_is_reported_as_a_virtual_plan() {
+        let routine = routine();
+        let created = LocalDate::parse("2026-01-05").unwrap();
+        let destination = LocalDate::parse("2026-01-06").unwrap();
+        let unscheduled = LocalDate::parse("2026-01-10").unwrap();
+        let target = RoutinePlanTarget {
+            routine: &routine,
+            created_local_date: created,
+        };
+
+        assert!(has_virtual_plan_on_date(target, &[], destination));
+        assert!(!has_virtual_plan_on_date(target, &[], unscheduled));
     }
 
     #[test]

--- a/crates/frilday-core/src/planning.rs
+++ b/crates/frilday-core/src/planning.rs
@@ -136,7 +136,9 @@ struct PlanKey(crate::RoutineId, LocalDate);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{PlanStatus, PlannedDuration, RoutineId, ScheduleRule, Timestamp};
+    use crate::{
+        PlanStatus, PlannedDuration, RoutineId, ScheduleRule, Session, SessionId, Timestamp,
+    };
 
     fn routine() -> Routine {
         Routine::new(
@@ -276,5 +278,43 @@ mod tests {
         assert_eq!(plans.len(), 1);
         assert_eq!(plans[0].effective_date(), destination);
         assert_eq!(plans[0].date(), source);
+    }
+
+    #[test]
+    fn moving_onto_a_scheduled_date_keeps_one_effective_occurrence() {
+        let routine = routine();
+        let source = LocalDate::parse("2026-01-05").unwrap();
+        let destination = LocalDate::parse("2026-01-06").unwrap();
+        let mut moved = Plan::from_routine(&routine, source, source).unwrap();
+        moved.move_to(destination);
+        let targets = [RoutinePlanTarget {
+            routine: &routine,
+            created_local_date: source,
+        }];
+
+        let plans = resolve_plans(&targets, &[moved], &[], source, destination);
+
+        assert_eq!(plans.len(), 1);
+        assert_eq!(plans[0].effective_date(), destination);
+    }
+
+    #[test]
+    fn history_makes_a_plan_immutable_for_adjustments() {
+        let routine = routine();
+        let date = LocalDate::parse("2026-01-05").unwrap();
+        let plan = Plan::from_routine(&routine, date, date).unwrap();
+        let completion =
+            Completion::for_routine_and_plan(routine.id().clone(), plan.id().clone(), date);
+        assert!(plan.has_history(&[completion], &[]));
+
+        let session = Session::start(
+            SessionId::new("session-1").unwrap(),
+            Some(routine.id().clone()),
+            Some(plan.id().clone()),
+            date,
+            Timestamp::from_unix_seconds(1_767_225_600),
+        )
+        .unwrap();
+        assert!(plan.has_history(&[], &[session]));
     }
 }

--- a/crates/frilday-core/src/session.rs
+++ b/crates/frilday-core/src/session.rs
@@ -121,6 +121,7 @@ impl Session {
     }
 
     /// Rehydrate a session from durable lifecycle state.
+    #[allow(clippy::too_many_arguments)]
     pub fn from_persisted(
         id: SessionId,
         routine_id: Option<RoutineId>,

--- a/crates/frilday-core/src/stats.rs
+++ b/crates/frilday-core/src/stats.rs
@@ -163,7 +163,7 @@ pub enum RoutineCategory {
     Custom,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct CompletionTotals {
     scheduled_count: u64,
     completed_count: u64,
@@ -409,13 +409,4 @@ fn date_range(start: LocalDate, end: LocalDate) -> Vec<LocalDate> {
         current = current.checked_add_days(1).expect("bounded date range");
     }
     dates
-}
-
-impl Default for CompletionTotals {
-    fn default() -> Self {
-        Self {
-            scheduled_count: 0,
-            completed_count: 0,
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- add date-specific Plan move/reschedule controls while preserving Routine defaults
- keep skip, duration override, restore, and history guardrails consistent across Today and Schedule
- reject destination collisions so a moved occurrence cannot silently duplicate an existing Plan
- add configurable daily planning capacity with advisory over-planning feedback
- add core/domain coverage for moved occurrence deduplication and historical Plan protection

## Verification
- bun run lint
- bun run build
- bun test
- cargo fmt --all -- --check
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings

Closes #21