### PR TITLE
[Validation] Validate routine-to-plan scheduling and time budgets

### DIFF
--- a/crates/frilday-core/src/planning.rs
+++ b/crates/frilday-core/src/planning.rs
@@ -158,6 +158,7 @@ mod tests {
     use super::*;
     use crate::{
         PlanStatus, PlannedDuration, RoutineId, ScheduleRule, Session, SessionId, Timestamp,
+        aggregate_for_date,
     };
 
     fn routine() -> Routine {
@@ -351,5 +352,62 @@ mod tests {
         )
         .unwrap();
         assert!(plan.has_history(&[], &[session]));
+    }
+
+    #[test]
+    fn executed_plan_keeps_its_snapshot_after_routine_changes_and_reload() {
+        let mut routine = routine();
+        let created = LocalDate::parse("2026-01-01").unwrap();
+        let date = LocalDate::parse("2026-01-05").unwrap();
+        let mut plan = Plan::from_routine(&routine, date, created).unwrap();
+        plan.set_duration_override(Some(PlannedDuration::from_minutes(90).unwrap()));
+        let completion =
+            crate::Completion::for_routine_and_plan(routine.id().clone(), plan.id().clone(), date);
+        let session = Session::new(
+            SessionId::new("session-history").unwrap(),
+            Some(routine.id().clone()),
+            Some(plan.id().clone()),
+            date,
+            Timestamp::from_unix_seconds(1_767_600_000),
+            Some(Timestamp::from_unix_seconds(1_767_601_800)),
+        )
+        .unwrap();
+
+        routine.set_starts_on(Some(LocalDate::parse("2026-02-01").unwrap()));
+        routine.archive();
+        let target = RoutinePlanTarget {
+            routine: &routine,
+            created_local_date: created,
+        };
+
+        let resolved = resolve_plans(
+            &[target],
+            std::slice::from_ref(&plan),
+            std::slice::from_ref(&completion),
+            date,
+            date,
+        );
+        let reloaded = resolve_plans(
+            &[target],
+            std::slice::from_ref(&plan),
+            std::slice::from_ref(&completion),
+            date,
+            date,
+        );
+
+        assert_eq!(resolved, reloaded);
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].id(), plan.id());
+        assert_eq!(resolved[0].planned_duration().minutes(), 90);
+        assert_eq!(
+            aggregate_for_date(
+                &resolved,
+                std::slice::from_ref(&session),
+                date,
+                Timestamp::from_unix_seconds(1_767_610_000),
+            )
+            .actual_minutes(),
+            30
+        );
     }
 }

--- a/docs/PLANNING_VALIDATION.md
+++ b/docs/PLANNING_VALIDATION.md
@@ -1,0 +1,45 @@
+# Planning model validation
+
+This is the final validation record for [#22](../issues/22) and the
+completion evidence for [#17](../issues/17).
+The validation was run against the planning implementation on `main` after
+PR #45.
+
+## Scenario results
+
+| Scenario | Result | Evidence |
+| --- | --- | --- |
+| Routine → Plan | Pass | `resolve_plans` derives one deterministic Plan per eligible Routine/date; `planning.rs` covers stable IDs and range de-duplication. |
+| One-day duration override | Pass | Persisted Plan override wins after Routine changes; desktop projection sums the effective duration and leaves the Routine default unchanged. |
+| Skip and restore | Pass | Skipped Plans remain visible for context but are excluded from executable totals; restoring removes the exception when there is no history. |
+| Move | Pass | A moved Plan is projected at its destination and a scheduled destination still yields one effective occurrence; destination collisions are rejected by the desktop store. |
+| Historical stability | Pass | Plans with Session/Completion history are protected from adjustment; persisted snapshots remain stable after schedule changes and archive, including after re-resolution. Legacy records are backfilled to stable Plan IDs. |
+| Daily and weekly budget | Pass | The weekly projection sums effective executable Plan durations by day and week, while skipped duration is reported separately. |
+| Over-planning feedback | Pass | A persisted, configurable daily capacity drives an advisory warning when planned minutes exceed capacity. |
+| Time-budget-first UX | Pass | The Schedule surface makes daily/week planned duration and load bars primary; Plan count is secondary summary context. |
+
+The core model keeps Routine, Plan, Session, and Completion separate. Planned
+minutes are aggregated independently from actual Session minutes, and
+Completion remains an independent signal. See
+[DOMAIN_MODEL.md](DOMAIN_MODEL.md) for the materialization and migration
+decisions.
+
+## Automated checks
+
+All supported repository checks passed after installing the locked desktop
+dependencies with `bun install --frozen-lockfile`:
+
+| Check | Result |
+| --- | --- |
+| `bun run test` in `apps/desktop` | Pass — 30 tests |
+| `bun run lint` in `apps/desktop` | Pass |
+| `bun run build` in `apps/desktop` | Pass |
+| `cargo fmt --all -- --check` | Pass |
+| `cargo check --workspace --locked` | Pass |
+| `cargo test --workspace --locked` | Pass — 38 core tests, 9 desktop tests |
+| `cargo clippy --workspace --all-targets --locked -- -D warnings` | Pass |
+
+The repository has no headless GUI click-through harness. The state
+transitions above are covered at the core, Tauri command, persistence, and
+weekly projection boundaries; a visual desktop smoke test remains a separate
+human-run check when a display is available.


### PR DESCRIPTION
## Summary
- record the end-to-end validation for planning Epic #17 and mandatory Validation #22
- add a regression test proving executed Plan snapshots retain identity, override, and actual time after Routine changes/archive/re-resolution

## Validation
- `bun install --frozen-lockfile` in `apps/desktop`
- `bun run test` — 30 passed
- `bun run lint`
- `bun run build`
- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo test --workspace --locked` — 38 core + 9 desktop tests passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings`

Scenario coverage includes deterministic duplicate-free Routine → Plan resolution, one-day overrides, skip/restore, move collision protection, daily/weekly planned totals, advisory capacity feedback, time-budget-first UX, and historical Session/Completion stability.

A visual GUI click-through was not available in this headless environment; core, Tauri adapter, persistence, and projection boundaries are covered by automated checks.

Closes #22
Closes #17